### PR TITLE
fix: avoid using floats when generating shares and added PoW validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
     #  on stable Rust.
     name: cargo check with stable
     runs-on: [ self-hosted, ubuntu-high-cpu ]
+    env:
+      RUSTUP_PERMIT_COPY_RENAME: true
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Description
---
When calculated shares floats were used, but since float rounding can be different across machines and systems, added integers only to avoid different shares generated.

Motivation and Context
---

How Has This Been Tested?
---
By running the normal mining process through p2pool (using 2 miners and 2 p2pool instances).

What process can a PR reviewer use to test or verify this change?
---
By running the normal mining process through p2pool (using 2 miners and 2 p2pool instances) and everything seems to work as before.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
