### PR TITLE
feat: generate and use private key from environment variable and add support for dnsaddr seed peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
@@ -4282,6 +4294,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -5194,6 +5207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,7 +5334,7 @@ dependencies = [
  "prost-derive",
  "rustls-pemfile 1.0.4",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util 0.7.11",
  "tower",
@@ -5434,7 +5457,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "trust-dns-proto",
+ "trust-dns-proto 0.21.2",
  "webpki",
 ]
 
@@ -5463,9 +5486,62 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "url",
  "webpki",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.0",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "rustls-webpki 0.101.7",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "rustls 0.21.12",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "trust-dns-proto 0.23.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5731,6 +5807,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,10 +1690,13 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "socket2",
  "thiserror",
  "tinyvec",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
 ]
@@ -1713,9 +1716,11 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
+ "rustls 0.21.12",
  "smallvec",
  "thiserror",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tracing",
 ]
 
@@ -4274,6 +4279,7 @@ dependencies = [
  "digest",
  "dirs",
  "hex",
+ "hickory-resolver",
  "itertools 0.13.0",
  "libp2p",
  "log",
@@ -4294,7 +4300,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "trust-dns-resolver",
 ]
 
 [[package]]
@@ -5457,7 +5462,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "trust-dns-proto 0.21.2",
+ "trust-dns-proto",
  "webpki",
 ]
 
@@ -5489,59 +5494,6 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "url",
  "webpki",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.6.0",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "rustls-webpki 0.101.7",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls 0.24.1",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "rustls 0.21.12",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls 0.24.1",
- "tracing",
- "trust-dns-proto 0.23.2",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5807,12 +5759,6 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,11 +4164,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
  "clap 4.5.9",
  "digest",
  "dirs",
+ "hex",
  "itertools 0.13.0",
  "libp2p",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_cbor",
+ "serde_json",
  "tari_common",
  "tari_common_types",
  "tari_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ itertools = "0.13.0"
 num = { version = "0.4.3", features = ["default", "num-bigint", "serde"] }
 hex = "0.4.3"
 serde_json = "1.0.122"
-trust-dns-resolver = { version = "*", features = ["dns-over-rustls"] }
+hickory-resolver = { version = "*", features = ["dns-over-rustls"] }
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ log4rs = "1.3.0"
 axum = "0.7.5"
 itertools = "0.13.0"
 num = { version = "0.4.3", features = ["default", "num-bigint", "serde"] }
+hex = "0.4.3"
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ itertools = "0.13.0"
 num = { version = "0.4.3", features = ["default", "num-bigint", "serde"] }
 hex = "0.4.3"
 serde_json = "1.0.122"
+trust-dns-resolver = { version = "*", features = ["dns-over-rustls"] }
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ axum = "0.7.5"
 itertools = "0.13.0"
 num = { version = "0.4.3", features = ["default", "num-bigint", "serde"] }
 hex = "0.4.3"
+serde_json = "1.0.122"
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> anyhow::Result<()> {
     // generate identity
     if cli.generate_identity {
         let result = p2p::util::generate_identity().await?;
-        print!("{}", serde_json::to_value(&result)?);
+        print!("{}", serde_json::to_value(result)?);
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,8 @@ use clap::{
 };
 use libp2p::identity::Keypair;
 use tari_common::initialize_logging;
-use tari_utilities::hex::Hex;
 
 use crate::server::p2p;
-use crate::server::p2p::util::GenerateIdentityResult;
 use crate::sharechain::in_memory::InMemoryShareChain;
 
 mod server;
@@ -120,7 +118,7 @@ async fn main() -> anyhow::Result<()> {
     // generate identity
     if cli.generate_identity {
         let result = p2p::util::generate_identity().await?;
-        print!("{}", serde_cbor::to_vec(&result)?.to_hex());
+        print!("{}", serde_json::to_value(&result)?);
         return Ok(());
     }
 
@@ -150,8 +148,7 @@ async fn main() -> anyhow::Result<()> {
     // try to extract env var based private key
     if let Ok(identity_cbor) = env::var("SHA_P2POOL_IDENTITY") {
         let identity_raw = hex::decode(identity_cbor.as_bytes())?;
-        let identity: GenerateIdentityResult = serde_cbor::from_slice(identity_raw.as_slice())?;
-        let private_key = Keypair::from_protobuf_encoding(identity.private_key().as_slice())?;
+        let private_key = Keypair::from_protobuf_encoding(identity_raw.as_slice())?;
         config_builder.with_private_key(Some(private_key));
     }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -3,6 +3,8 @@
 
 use std::{path::PathBuf, time::Duration};
 
+use libp2p::identity::Keypair;
+
 use crate::server::http::stats;
 use crate::server::{p2p, p2p::peer_store::PeerStoreConfig};
 
@@ -85,6 +87,11 @@ impl ConfigBuilder {
 
     pub fn with_private_key_folder(&mut self, config: PathBuf) -> &mut Self {
         self.config.p2p_service.private_key_folder = config;
+        self
+    }
+
+    pub fn with_private_key(&mut self, config: Option<Keypair>) -> &mut Self {
+        self.config.p2p_service.private_key = config;
         self
     }
 

--- a/src/server/p2p/error.rs
+++ b/src/server/p2p/error.rs
@@ -27,6 +27,8 @@ pub enum LibP2PError {
     Noise(#[from] noise::Error),
     #[error("Multi address parse error: {0}")]
     MultiAddrParse(#[from] multiaddr::Error),
+    #[error("Multi address empty")]
+    MultiAddrEmpty,
     #[error("Transport error: {0}")]
     Transport(#[from] TransportError<std::io::Error>),
     #[error("I/O error: {0}")]

--- a/src/server/p2p/error.rs
+++ b/src/server/p2p/error.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::string::FromUtf8Error;
+
 use libp2p::{
     gossipsub::PublishError, identity::DecodingError, kad::NoKnownPeers, multiaddr, noise, swarm::DialError,
     TransportError,
@@ -45,4 +47,8 @@ pub enum LibP2PError {
     MissingPeerId(String),
     #[error("Key decode error: {0}")]
     KeyDecoding(#[from] DecodingError),
+    #[error("Invalid DNS entry: {0}")]
+    InvalidDnsEntry(String),
+    #[error("Failed to convert bytes to string: {0}")]
+    ConvertBytesToString(#[from] FromUtf8Error),
 }

--- a/src/server/p2p/mod.rs
+++ b/src/server/p2p/mod.rs
@@ -13,3 +13,4 @@ mod error;
 pub mod messages;
 mod network;
 pub mod peer_store;
+pub mod util;

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -1,31 +1,31 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
     path::PathBuf,
     sync::Arc,
     time::Duration,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
-use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
     futures::StreamExt,
     gossipsub,
     gossipsub::{IdentTopic, Message, PublishError},
     identity::Keypair,
     kad,
-    kad::{store::MemoryStore, Event, Mode},
+    kad::{Event, Mode, store::MemoryStore},
     mdns,
     mdns::tokio::Tokio,
-    multiaddr::Protocol,
-    noise, request_response,
+    Multiaddr,
+    multiaddr::Protocol, noise,
+    request_response,
     request_response::{cbor, ResponseChannel},
-    swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, StreamProtocol, Swarm,
+    StreamProtocol, swarm::{NetworkBehaviour, SwarmEvent}, Swarm, tcp, yamux,
 };
+use libp2p::swarm::behaviour::toggle::Toggle;
 use log::{debug, error, info, warn};
 use tari_common::configuration::Network;
 use tari_utilities::hex::Hex;
@@ -37,25 +37,25 @@ use tokio::{
     sync::{broadcast, broadcast::error::RecvError},
 };
 
-use crate::server::p2p::messages::LocalShareChainSyncRequest;
 use crate::{
     server::{
         config,
         p2p::{
+            Error,
+            LibP2PError,
             messages,
-            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse},
-            peer_store::PeerStore,
-            Error, LibP2PError, ServiceClient,
+            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse}, peer_store::PeerStore, ServiceClient,
         },
     },
     sharechain::{block::Block, ShareChain},
 };
+use crate::server::p2p::messages::LocalShareChainSyncRequest;
 
 const PEER_INFO_TOPIC: &str = "peer_info";
 const NEW_BLOCK_TOPIC: &str = "new_block";
 const SHARE_CHAIN_SYNC_REQ_RESP_PROTOCOL: &str = "/share_chain_sync/1";
 const LOG_TARGET: &str = "p2pool::server::p2p";
-const STABLE_PRIVATE_KEY_FILE: &str = "p2pool_private.key";
+pub const STABLE_PRIVATE_KEY_FILE: &str = "p2pool_private.key";
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -279,17 +279,17 @@ where
                             .publish(IdentTopic::new(Self::topic_name(NEW_BLOCK_TOPIC)), block_raw)
                             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))
                         {
-                            Ok(_) => {},
+                            Ok(_) => {}
                             Err(error) => {
                                 error!(target: LOG_TARGET, "Failed to broadcast new block: {error:?}")
-                            },
+                            }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, "Failed to convert block to bytes: {error:?}")
-                    },
+                    }
                 }
-            },
+            }
             Err(error) => error!(target: LOG_TARGET, "Failed to receive new block: {error:?}"),
         }
     }
@@ -339,10 +339,10 @@ where
                             }
                         }
                     }
-                },
+                }
                 Err(error) => {
                     error!(target: LOG_TARGET, "Can't deserialize peer info payload: {:?}", error);
-                },
+                }
             },
             // TODO: send a signature that proves that the actual block was coming from this peer
             // TODO: (sender peer's wallet address should be included always in the conibases with a fixed percent (like 20%))
@@ -359,20 +359,20 @@ where
                                 if result.need_sync {
                                     self.sync_share_chain().await;
                                 }
-                            },
+                            }
                             Err(error) => {
                                 error!(target: LOG_TARGET, "Could not add new block to local share chain: {error:?}");
-                            },
+                            }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, "Can't deserialize broadcast block payload: {:?}", error);
-                    },
+                    }
                 }
-            },
+            }
             _ => {
                 warn!(target: LOG_TARGET, "Unknown topic {topic:?}!");
-            },
+            }
         }
     }
 
@@ -394,7 +394,7 @@ where
                 {
                     error!(target: LOG_TARGET, "Failed to send block sync response");
                 }
-            },
+            }
             Err(error) => error!(target: LOG_TARGET, "Failed to get blocks from height: {error:?}"),
         }
     }
@@ -411,10 +411,10 @@ where
                 if result.need_sync {
                     self.sync_share_chain().await;
                 }
-            },
+            }
             Err(error) => {
                 error!(target: LOG_TARGET, "Failed to add synced blocks to share chain: {error:?}");
-            },
+            }
         }
     }
 
@@ -437,11 +437,11 @@ where
                     .behaviour_mut()
                     .share_chain_sync
                     .send_request(&result.peer_id, ShareChainSyncRequest::new(0));
-            },
+            }
             None => {
                 self.sync_in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
-            },
+            }
         }
     }
 
@@ -485,17 +485,17 @@ where
                         } else {
                             in_progress.store(false, Ordering::SeqCst);
                         }
-                    },
+                    }
                     Err(error) => {
                         in_progress.store(false, Ordering::SeqCst);
                         error!(target: LOG_TARGET, "Failed to get latest height of share chain: {error:?}")
-                    },
+                    }
                 }
-            },
+            }
             None => {
                 in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
-            },
+            }
         }
     }
 
@@ -504,7 +504,7 @@ where
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(target: LOG_TARGET, "Listening on {address:?}");
-            },
+            }
             SwarmEvent::Behaviour(event) => match event {
                 ServerNetworkBehaviourEvent::Mdns(mdns_event) => match mdns_event {
                     mdns::Event::Discovered(peers) => {
@@ -512,12 +512,12 @@ where
                             self.swarm.add_peer_address(peer, addr);
                             self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer);
                         }
-                    },
+                    }
                     mdns::Event::Expired(peers) => {
                         for (peer, _addr) in peers {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&peer);
                         }
-                    },
+                    }
                 },
                 ServerNetworkBehaviourEvent::Gossipsub(event) => match event {
                     gossipsub::Event::Message {
@@ -526,10 +526,10 @@ where
                         propagation_source: _propagation_source,
                     } => {
                         self.handle_new_gossipsub_message(message).await;
-                    },
-                    gossipsub::Event::Subscribed { .. } => {},
-                    gossipsub::Event::Unsubscribed { .. } => {},
-                    gossipsub::Event::GossipsubNotSupported { .. } => {},
+                    }
+                    gossipsub::Event::Subscribed { .. } => {}
+                    gossipsub::Event::Unsubscribed { .. } => {}
+                    gossipsub::Event::GossipsubNotSupported { .. } => {}
                 },
                 ServerNetworkBehaviourEvent::ShareChainSync(event) => match event {
                     request_response::Event::Message { peer: _peer, message } => match message {
@@ -539,27 +539,27 @@ where
                             channel,
                         } => {
                             self.handle_share_chain_sync_request(channel, request).await;
-                        },
+                        }
                         request_response::Message::Response {
                             request_id: _request_id,
                             response,
                         } => {
                             self.handle_share_chain_sync_response(response).await;
-                        },
+                        }
                     },
                     request_response::Event::OutboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, "REQ-RES outbound failure: {peer:?} -> {error:?}");
-                    },
+                    }
                     request_response::Event::InboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, "REQ-RES inbound failure: {peer:?} -> {error:?}");
-                    },
-                    request_response::Event::ResponseSent { .. } => {},
+                    }
+                    request_response::Event::ResponseSent { .. } => {}
                 },
                 ServerNetworkBehaviourEvent::Kademlia(event) => match event {
                     Event::RoutingUpdated {
@@ -575,11 +575,11 @@ where
                         if let Some(old_peer) = old_peer {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&old_peer);
                         }
-                    },
+                    }
                     _ => debug!(target: LOG_TARGET, "[KADEMLIA] {event:?}"),
                 },
             },
-            _ => {},
+            _ => {}
         };
     }
 
@@ -701,7 +701,7 @@ where
                 share_chain_sync_tx,
                 Duration::from_secs(30),
             )
-            .await;
+                .await;
         });
 
         self.main_loop().await

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -1,31 +1,31 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
     path::PathBuf,
     sync::Arc,
     time::Duration,
 };
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
 
+use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
     futures::StreamExt,
     gossipsub,
     gossipsub::{IdentTopic, Message, PublishError},
     identity::Keypair,
     kad,
-    kad::{Event, Mode, store::MemoryStore},
+    kad::{store::MemoryStore, Event, Mode},
     mdns,
     mdns::tokio::Tokio,
-    Multiaddr,
-    multiaddr::Protocol, noise,
-    request_response,
+    multiaddr::Protocol,
+    noise, request_response,
     request_response::{cbor, ResponseChannel},
-    StreamProtocol, swarm::{NetworkBehaviour, SwarmEvent}, Swarm, tcp, yamux,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Multiaddr, StreamProtocol, Swarm,
 };
-use libp2p::swarm::behaviour::toggle::Toggle;
 use log::{debug, error, info, warn};
 use tari_common::configuration::Network;
 use tari_utilities::hex::Hex;
@@ -37,19 +37,19 @@ use tokio::{
     sync::{broadcast, broadcast::error::RecvError},
 };
 
+use crate::server::p2p::messages::LocalShareChainSyncRequest;
 use crate::{
     server::{
         config,
         p2p::{
-            Error,
-            LibP2PError,
             messages,
-            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse}, peer_store::PeerStore, ServiceClient,
+            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse},
+            peer_store::PeerStore,
+            Error, LibP2PError, ServiceClient,
         },
     },
     sharechain::{block::Block, ShareChain},
 };
-use crate::server::p2p::messages::LocalShareChainSyncRequest;
 
 const PEER_INFO_TOPIC: &str = "peer_info";
 const NEW_BLOCK_TOPIC: &str = "new_block";
@@ -63,6 +63,7 @@ pub struct Config {
     pub peer_info_publish_interval: Duration,
     pub stable_peer: bool,
     pub private_key_folder: PathBuf,
+    pub private_key: Option<Keypair>,
     pub mdns_enabled: bool,
 }
 
@@ -73,6 +74,7 @@ impl Default for Config {
             peer_info_publish_interval: Duration::from_secs(5),
             stable_peer: false,
             private_key_folder: PathBuf::from("."),
+            private_key: None,
             mdns_enabled: false,
         }
     }
@@ -147,7 +149,12 @@ where
             return Ok(Keypair::generate_ed25519());
         }
 
-        // if we have a saved private key, just use it
+        // if we have a private key set, use it instead
+        if let Some(private_key) = &config.private_key {
+            return Ok(private_key.clone());
+        }
+
+        // if we have a saved private key from file, just use it
         let mut content = vec![];
         let mut key_path = config.private_key_folder.clone();
         key_path.push(STABLE_PRIVATE_KEY_FILE);
@@ -279,17 +286,17 @@ where
                             .publish(IdentTopic::new(Self::topic_name(NEW_BLOCK_TOPIC)), block_raw)
                             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))
                         {
-                            Ok(_) => {}
+                            Ok(_) => {},
                             Err(error) => {
                                 error!(target: LOG_TARGET, "Failed to broadcast new block: {error:?}")
-                            }
+                            },
                         }
-                    }
+                    },
                     Err(error) => {
                         error!(target: LOG_TARGET, "Failed to convert block to bytes: {error:?}")
-                    }
+                    },
                 }
-            }
+            },
             Err(error) => error!(target: LOG_TARGET, "Failed to receive new block: {error:?}"),
         }
     }
@@ -339,10 +346,10 @@ where
                             }
                         }
                     }
-                }
+                },
                 Err(error) => {
                     error!(target: LOG_TARGET, "Can't deserialize peer info payload: {:?}", error);
-                }
+                },
             },
             // TODO: send a signature that proves that the actual block was coming from this peer
             // TODO: (sender peer's wallet address should be included always in the conibases with a fixed percent (like 20%))
@@ -359,20 +366,20 @@ where
                                 if result.need_sync {
                                     self.sync_share_chain().await;
                                 }
-                            }
+                            },
                             Err(error) => {
                                 error!(target: LOG_TARGET, "Could not add new block to local share chain: {error:?}");
-                            }
+                            },
                         }
-                    }
+                    },
                     Err(error) => {
                         error!(target: LOG_TARGET, "Can't deserialize broadcast block payload: {:?}", error);
-                    }
+                    },
                 }
-            }
+            },
             _ => {
                 warn!(target: LOG_TARGET, "Unknown topic {topic:?}!");
-            }
+            },
         }
     }
 
@@ -394,7 +401,7 @@ where
                 {
                     error!(target: LOG_TARGET, "Failed to send block sync response");
                 }
-            }
+            },
             Err(error) => error!(target: LOG_TARGET, "Failed to get blocks from height: {error:?}"),
         }
     }
@@ -411,10 +418,10 @@ where
                 if result.need_sync {
                     self.sync_share_chain().await;
                 }
-            }
+            },
             Err(error) => {
                 error!(target: LOG_TARGET, "Failed to add synced blocks to share chain: {error:?}");
-            }
+            },
         }
     }
 
@@ -437,11 +444,11 @@ where
                     .behaviour_mut()
                     .share_chain_sync
                     .send_request(&result.peer_id, ShareChainSyncRequest::new(0));
-            }
+            },
             None => {
                 self.sync_in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
-            }
+            },
         }
     }
 
@@ -485,17 +492,17 @@ where
                         } else {
                             in_progress.store(false, Ordering::SeqCst);
                         }
-                    }
+                    },
                     Err(error) => {
                         in_progress.store(false, Ordering::SeqCst);
                         error!(target: LOG_TARGET, "Failed to get latest height of share chain: {error:?}")
-                    }
+                    },
                 }
-            }
+            },
             None => {
                 in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
-            }
+            },
         }
     }
 
@@ -504,7 +511,7 @@ where
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(target: LOG_TARGET, "Listening on {address:?}");
-            }
+            },
             SwarmEvent::Behaviour(event) => match event {
                 ServerNetworkBehaviourEvent::Mdns(mdns_event) => match mdns_event {
                     mdns::Event::Discovered(peers) => {
@@ -512,12 +519,12 @@ where
                             self.swarm.add_peer_address(peer, addr);
                             self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer);
                         }
-                    }
+                    },
                     mdns::Event::Expired(peers) => {
                         for (peer, _addr) in peers {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&peer);
                         }
-                    }
+                    },
                 },
                 ServerNetworkBehaviourEvent::Gossipsub(event) => match event {
                     gossipsub::Event::Message {
@@ -526,10 +533,10 @@ where
                         propagation_source: _propagation_source,
                     } => {
                         self.handle_new_gossipsub_message(message).await;
-                    }
-                    gossipsub::Event::Subscribed { .. } => {}
-                    gossipsub::Event::Unsubscribed { .. } => {}
-                    gossipsub::Event::GossipsubNotSupported { .. } => {}
+                    },
+                    gossipsub::Event::Subscribed { .. } => {},
+                    gossipsub::Event::Unsubscribed { .. } => {},
+                    gossipsub::Event::GossipsubNotSupported { .. } => {},
                 },
                 ServerNetworkBehaviourEvent::ShareChainSync(event) => match event {
                     request_response::Event::Message { peer: _peer, message } => match message {
@@ -539,27 +546,27 @@ where
                             channel,
                         } => {
                             self.handle_share_chain_sync_request(channel, request).await;
-                        }
+                        },
                         request_response::Message::Response {
                             request_id: _request_id,
                             response,
                         } => {
                             self.handle_share_chain_sync_response(response).await;
-                        }
+                        },
                     },
                     request_response::Event::OutboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, "REQ-RES outbound failure: {peer:?} -> {error:?}");
-                    }
+                    },
                     request_response::Event::InboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, "REQ-RES inbound failure: {peer:?} -> {error:?}");
-                    }
-                    request_response::Event::ResponseSent { .. } => {}
+                    },
+                    request_response::Event::ResponseSent { .. } => {},
                 },
                 ServerNetworkBehaviourEvent::Kademlia(event) => match event {
                     Event::RoutingUpdated {
@@ -575,11 +582,11 @@ where
                         if let Some(old_peer) = old_peer {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&old_peer);
                         }
-                    }
+                    },
                     _ => debug!(target: LOG_TARGET, "[KADEMLIA] {event:?}"),
                 },
             },
-            _ => {}
+            _ => {},
         };
     }
 
@@ -701,7 +708,7 @@ where
                 share_chain_sync_tx,
                 Duration::from_secs(30),
             )
-                .await;
+            .await;
         });
 
         self.main_loop().await

--- a/src/server/p2p/util.rs
+++ b/src/server/p2p/util.rs
@@ -2,30 +2,25 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use libp2p::identity::Keypair;
-use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct GenerateIdentityResult {
-    peer_id: PeerId,
     private_key: Vec<u8>,
 }
 
 impl GenerateIdentityResult {
-    pub fn new(peer_id: PeerId, private_key: Vec<u8>) -> Self {
-        Self {
-            peer_id,
-            private_key,
-        }
+    pub fn new(private_key: Vec<u8>) -> Self {
+        Self { private_key }
+    }
+
+    pub fn private_key(&self) -> &Vec<u8> {
+        &self.private_key
     }
 }
 
 pub async fn generate_identity() -> anyhow::Result<GenerateIdentityResult> {
-    let key_pair = Keypair::generate_ed25519();
-    let encoded_private_key = key_pair.to_protobuf_encoding()?;
-
     Ok(GenerateIdentityResult::new(
-        key_pair.public().to_peer_id(),
-        encoded_private_key,
+        Keypair::generate_ed25519().to_protobuf_encoding()?,
     ))
 }

--- a/src/server/p2p/util.rs
+++ b/src/server/p2p/util.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use libp2p::identity::Keypair;
+use libp2p::PeerId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct GenerateIdentityResult {
+    peer_id: PeerId,
+    private_key: Vec<u8>,
+}
+
+impl GenerateIdentityResult {
+    pub fn new(peer_id: PeerId, private_key: Vec<u8>) -> Self {
+        Self {
+            peer_id,
+            private_key,
+        }
+    }
+}
+
+pub async fn generate_identity() -> anyhow::Result<GenerateIdentityResult> {
+    let key_pair = Keypair::generate_ed25519();
+    let encoded_private_key = key_pair.to_protobuf_encoding()?;
+
+    Ok(GenerateIdentityResult::new(
+        key_pair.public().to_peer_id(),
+        encoded_private_key,
+    ))
+}

--- a/src/server/p2p/util.rs
+++ b/src/server/p2p/util.rs
@@ -2,26 +2,28 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use libp2p::identity::Keypair;
+use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
+use tari_utilities::hex::Hex;
 
 #[derive(Serialize, Deserialize)]
 pub struct GenerateIdentityResult {
-    private_key: Vec<u8>,
+    peer_id: PeerId,
+    private_key: String,
 }
 
 impl GenerateIdentityResult {
-    pub fn new(private_key: Vec<u8>) -> Self {
-        Self { private_key }
-    }
-
-    pub fn private_key(&self) -> &Vec<u8> {
-        &self.private_key
+    pub fn new(peer_id: PeerId, private_key: String) -> Self {
+        Self { peer_id, private_key }
     }
 }
 
-/// Generates a new private key that can be used to return when generating identity.
+/// Generates a new identity (private key for libp2p).
 pub async fn generate_identity() -> anyhow::Result<GenerateIdentityResult> {
+    let private_key = Keypair::generate_ed25519();
+    let private_key_raw = private_key.to_protobuf_encoding()?.to_hex();
     Ok(GenerateIdentityResult::new(
-        Keypair::generate_ed25519().to_protobuf_encoding()?,
+        private_key.public().to_peer_id(),
+        private_key_raw,
     ))
 }

--- a/src/server/p2p/util.rs
+++ b/src/server/p2p/util.rs
@@ -19,6 +19,7 @@ impl GenerateIdentityResult {
     }
 }
 
+/// Generates a new private key that can be used to return when generating identity.
 pub async fn generate_identity() -> anyhow::Result<GenerateIdentityResult> {
     Ok(GenerateIdentityResult::new(
         Keypair::generate_ed25519().to_protobuf_encoding()?,

--- a/src/sharechain/in_memory.rs
+++ b/src/sharechain/in_memory.rs
@@ -238,7 +238,7 @@ impl ShareChain for InMemoryShareChain {
             .await;
         let chain = self.chain(block_levels_write_lock.iter());
         let last_block = chain.last().ok_or_else(|| Error::Empty)?;
-        info!(target: LOG_TARGET, "⬆️  Current height: {:?}", last_block.height());
+        info!(target: LOG_TARGET, "⬆️ Current height: {:?}", last_block.height());
         result
     }
 
@@ -268,7 +268,7 @@ impl ShareChain for InMemoryShareChain {
 
         let chain = self.chain(block_levels_write_lock.iter());
         let last_block = chain.last().ok_or_else(|| Error::Empty)?;
-        info!(target: LOG_TARGET, "⬆️  Current height: {:?}", last_block.height());
+        info!(target: LOG_TARGET, "⬆️ Current height: {:?}", last_block.height());
 
         Ok(SubmitBlockResult::new(false))
     }


### PR DESCRIPTION
Description
---
In order to generate a private key earlier that can be used at any start from env vars, we needed a solution.
Now there is a new cli option called `--generate-identity`. With this option, you can generate a new identity (an encoded libp2p private key) that can be used to set value later for `SHA_P2POOL_IDENTITY` environment variable (the command outputs a json where `private_key` field is the one need to use).
If that var is set, when starting p2pool with `--stable-peer` flag, it will look for first for this env var and tries to decode and use it.
Also `/dnsaddr/*` seed peer addresses were not supported, now it is supported, so p2pool will parse all the TXT DNS records and add them to kademlia to bootstrap.

Motivation and Context
---

How Has This Been Tested?
---
```sh
cargo build --release
export SHA_P2POOL_IDENTITY=$(./target/release/sha_p2pool --generate-identity | jq -r '.private_key')
./target/release/sha_p2pool --stable-peer
```

After starting/stopping many times p2pool, the peer ID remains the same.

What process can a PR reviewer use to test or verify this change?
---
See testing.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
