### PR TITLE
feat: add tribes and graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,7 @@ dependencies = [
  "tari_common_types",
  "tari_core",
  "tari_crypto",
+ "tari_shutdown",
  "tari_utilities",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4285,7 @@ dependencies = [
  "axum 0.7.5",
  "blake2",
  "clap 4.5.9",
+ "convert_case",
  "digest",
  "dirs",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "sha_p2pool"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,6 +4302,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "signal-hook",
  "tari_common",
  "tari_common_types",
  "tari_core",
@@ -4311,6 +4312,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1.38.0", features = ["full"] }
 thiserror = "1.0"
 serde = "1.0.203"
 anyhow = "1.0"
-log = "0.4.21"
+log = { version = "0.4.21", features = ["kv"] }
 tonic = "0.8.3"
 async-trait = "0.1.80"
 serde_cbor = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git" }
 tari_common = { git = "https://github.com/tari-project/tari.git" }
 tari_core = { git = "https://github.com/tari-project/tari.git" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git" }
 
 tari_crypto = "0.20.1"
 tari_utilities = { version = "0.7", features = ["borsh"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ hex = "0.4.3"
 serde_json = "1.0.122"
 hickory-resolver = { version = "*", features = ["dns-over-rustls"] }
 convert_case = "0.6.0"
+signal-hook = "0.3.17"
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha_p2pool"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ num = { version = "0.4.3", features = ["default", "num-bigint", "serde"] }
 hex = "0.4.3"
 serde_json = "1.0.122"
 hickory-resolver = { version = "*", features = ["dns-over-rustls"] }
+convert_case = "0.6.0"
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,0 +1,151 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::{Parser, Subcommand};
+use tari_shutdown::ShutdownSignal;
+
+use crate::cli::commands;
+use crate::cli::util::cli_styles;
+use crate::cli::util::validate_tribe;
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Parser, Debug)]
+pub struct StartArgs {
+    /// (Optional) gRPC port to use.
+    #[arg(short, long, value_name = "grpc-port")]
+    pub grpc_port: Option<u16>,
+
+    /// (Optional) p2p port to use. It is used to connect p2pool nodes.
+    #[arg(short, long, value_name = "p2p-port")]
+    pub p2p_port: Option<u16>,
+
+    /// (Optional) stats server port to use.
+    #[arg(long, value_name = "stats-server-port")]
+    pub stats_server_port: Option<u16>,
+
+    /// (Optional) seed peers.
+    /// Any amount of seed peers can be added to join a p2pool network.
+    ///
+    /// Please note that these addresses must be in libp2p multi address format and must contain peer ID
+    /// or use a dnsaddr multi address!
+    ///
+    /// By default a Tari provided seed peer is added.
+    ///
+    /// e.g.:
+    /// /ip4/127.0.0.1/tcp/52313/p2p/12D3KooWCUNCvi7PBPymgsHx39JWErYdSoT3EFPrn3xoVff4CHFu
+    /// /dnsaddr/esmeralda.p2pool.tari.com
+    #[arg(short, long, value_name = "seed-peers")]
+    pub seed_peers: Option<Vec<String>>,
+
+    /// If set, Tari provided seed peers will NOT be automatically added to seed peers list.
+    #[arg(long, value_name = "no-default-seed-peers", default_value_t = false)]
+    pub no_default_seed_peers: bool,
+
+    /// Starts the node as a stable peer.
+    ///
+    /// Identity of the peer will be saved locally (to --private-key-location)
+    /// and ID of the Peer remains the same.
+    #[arg(long, value_name = "stable-peer", default_value_t = false)]
+    pub stable_peer: bool,
+
+    /// Tribe to enter (a team of miners).
+    /// A tribe can have any name.
+    #[arg(
+        long, value_name = "tribe", default_value = "default", value_parser = validate_tribe
+    )]
+    pub tribe: String,
+
+    /// Private key folder.
+    ///
+    /// Needs --stable-peer to be set.
+    #[arg(
+        long,
+        value_name = "private-key-folder",
+        requires = "stable_peer",
+        default_value = "."
+    )]
+    pub private_key_folder: PathBuf,
+
+    /// Mining disabled
+    ///
+    /// In case it is set, the node will only handle p2p operations,
+    /// will be syncing with share chain, but not starting gRPC services and no Tari base node needed.
+    /// By setting this it can be used as a stable node for routing only.
+    #[arg(long, value_name = "mining-disabled", default_value_t = false)]
+    pub mining_disabled: bool,
+
+    /// mDNS disabled
+    ///
+    /// If set, mDNS local peer discovery is disabled.
+    #[arg(long, value_name = "mdns-disabled", default_value_t = false)]
+    pub mdns_disabled: bool,
+
+    /// Stats server disabled
+    ///
+    /// If set, local stats HTTP server is disabled.
+    #[arg(long, value_name = "stats-server-disabled", default_value_t = false)]
+    pub stats_server_disabled: bool,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum Commands {
+    /// Starts sha-p2pool node.
+    Start {
+        #[clap(flatten)]
+        args: StartArgs,
+    },
+
+    /// Generating new identity.
+    GenerateIdentity,
+
+    /// Listing all tribes that are present on the network.
+    ListTribes {
+        #[clap(flatten)]
+        args: StartArgs,
+    },
+}
+
+#[derive(Clone, Parser)]
+#[command(version)]
+#[command(styles = cli_styles())]
+#[command(about = "⛏ Decentralized mining pool for Tari network ⛏", long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+
+    /// (Optional) base dir.
+    #[arg(short, long, value_name = "base-dir")]
+    base_dir: Option<PathBuf>,
+}
+
+impl Cli {
+    pub fn base_dir(&self) -> PathBuf {
+        self.base_dir
+            .clone()
+            .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/p2pool"))
+    }
+
+    /// Handles CLI command.
+    /// [`Cli::parse`] must be called (to have all the args and params set properly)
+    /// before calling this method.
+    pub async fn handle_command(&self, cli_shutdown: ShutdownSignal) -> anyhow::Result<()> {
+        let cli_ref = Arc::new(self.clone());
+
+        match &self.command {
+            Commands::Start { args } => {
+                commands::handle_start(cli_ref.clone(), args, cli_shutdown.clone()).await?;
+            },
+            Commands::GenerateIdentity => {
+                commands::handle_generate_identity().await?;
+            },
+            Commands::ListTribes { args } => {
+                commands::handle_list_tribes(cli_ref.clone(), args, cli_shutdown.clone()).await?;
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/commands/generate_identity.rs
+++ b/src/cli/commands/generate_identity.rs
@@ -1,0 +1,10 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::server::p2p;
+
+pub async fn handle_generate_identity() -> anyhow::Result<()> {
+    let result = p2p::util::generate_identity().await?;
+    print!("{}", serde_json::to_value(result)?);
+    Ok(())
+}

--- a/src/cli/commands/list_tribes.rs
+++ b/src/cli/commands/list_tribes.rs
@@ -1,0 +1,72 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use itertools::Itertools;
+use tari_shutdown::{Shutdown, ShutdownSignal};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::{select, time};
+
+use crate::cli::args::{Cli, StartArgs};
+use crate::cli::commands::util;
+use crate::server::p2p::peer_store::PeerStore;
+
+pub async fn handle_list_tribes(
+    cli: Arc<Cli>,
+    args: &StartArgs,
+    cli_shutdown_signal: ShutdownSignal,
+) -> anyhow::Result<()> {
+    // start server asynchronously
+    let cli_ref = cli.clone();
+    let mut args_clone = args.clone();
+    args_clone.mining_disabled = true;
+    args_clone.stats_server_disabled = true;
+    let mut shutdown = Shutdown::new();
+    let shutdown_signal = shutdown.to_signal();
+    let (peer_store_channel_tx, peer_store_channel_rx) = oneshot::channel::<Arc<PeerStore>>();
+    let handle: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
+        let mut server = util::server(cli_ref, &args_clone, shutdown_signal, false).await?;
+        match peer_store_channel_tx.send(server.p2p_service().network_peer_store().clone()) {
+            Ok(_) => server.start().await?,
+            Err(_) => return Err(anyhow!("Failed to start server")),
+        }
+
+        Ok(())
+    });
+
+    // wait for peer store from started server
+    let peer_store = peer_store_channel_rx.await?;
+
+    // collect tribes for 30 seconds
+    let mut tribes = vec![];
+    let timeout = time::sleep(Duration::from_secs(30));
+    tokio::pin!(timeout);
+    tokio::pin!(cli_shutdown_signal);
+    loop {
+        select! {
+            _ = &mut cli_shutdown_signal => {
+                break;
+            }
+            () = &mut timeout => {
+                break;
+            }
+            current_tribes = peer_store.tribes() => {
+                tribes = current_tribes;
+                if tribes.len() > 1 {
+                    break;
+                }
+            }
+        }
+    }
+    shutdown.trigger();
+    handle.await??;
+
+    let tribes = tribes.iter().map(|tribe| tribe.to_string()).collect_vec();
+    print!("{}", serde_json::to_value(tribes)?);
+
+    Ok(())
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,0 +1,11 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+pub use generate_identity::*;
+pub use list_tribes::*;
+pub use start::*;
+
+mod generate_identity;
+mod list_tribes;
+mod start;
+mod util;

--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -1,0 +1,17 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::sync::Arc;
+
+use tari_shutdown::ShutdownSignal;
+
+use crate::cli::args::{Cli, StartArgs};
+use crate::cli::commands::util;
+
+pub async fn handle_start(cli: Arc<Cli>, args: &StartArgs, cli_shutdown_signal: ShutdownSignal) -> anyhow::Result<()> {
+    util::server(cli, args, cli_shutdown_signal, true)
+        .await?
+        .start()
+        .await?;
+    Ok(())
+}

--- a/src/cli/commands/util.rs
+++ b/src/cli/commands/util.rs
@@ -1,0 +1,79 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::env;
+use std::sync::Arc;
+
+use libp2p::identity::Keypair;
+use tari_common::configuration::Network;
+use tari_common::initialize_logging;
+use tari_shutdown::ShutdownSignal;
+
+use crate::cli::args::{Cli, StartArgs};
+use crate::server as main_server;
+use crate::server::p2p::Tribe;
+use crate::server::Server;
+use crate::sharechain::in_memory::InMemoryShareChain;
+
+pub async fn server(
+    cli: Arc<Cli>,
+    args: &StartArgs,
+    shutdown_signal: ShutdownSignal,
+    enable_logging: bool,
+) -> anyhow::Result<Server<InMemoryShareChain>> {
+    if enable_logging {
+        // logger setup
+        if let Err(e) = initialize_logging(
+            &cli.base_dir().join("configs/logs.yml"),
+            &cli.base_dir(),
+            include_str!("../../../log4rs_sample.yml"),
+        ) {
+            eprintln!("{}", e);
+            return Err(e.into());
+        }
+    }
+
+    let mut config_builder = main_server::Config::builder();
+    if let Some(grpc_port) = args.grpc_port {
+        config_builder.with_grpc_port(grpc_port);
+    }
+    if let Some(p2p_port) = args.p2p_port {
+        config_builder.with_p2p_port(p2p_port);
+    }
+
+    config_builder.with_tribe(Tribe::from(args.tribe.clone()));
+
+    // set default tari network specific seed peer address
+    let mut seed_peers = vec![];
+    let network = Network::get_current_or_user_setting_or_default();
+    if network != Network::LocalNet && !args.no_default_seed_peers {
+        let default_seed_peer = format!("/dnsaddr/{}.p2pool.tari.com", network.as_key_str());
+        seed_peers.push(default_seed_peer);
+    }
+    if let Some(cli_seed_peers) = args.seed_peers.clone() {
+        seed_peers.extend(cli_seed_peers.iter().cloned());
+    }
+    config_builder.with_seed_peers(seed_peers);
+
+    config_builder.with_stable_peer(args.stable_peer);
+    config_builder.with_private_key_folder(args.private_key_folder.clone());
+
+    // try to extract env var based private key
+    if let Ok(identity_cbor) = env::var("SHA_P2POOL_IDENTITY") {
+        let identity_raw = hex::decode(identity_cbor.as_bytes())?;
+        let private_key = Keypair::from_protobuf_encoding(identity_raw.as_slice())?;
+        config_builder.with_private_key(Some(private_key));
+    }
+
+    config_builder.with_mining_enabled(!args.mining_disabled);
+    config_builder.with_mdns_enabled(!args.mdns_disabled);
+    config_builder.with_stats_server_enabled(!args.stats_server_disabled);
+    if let Some(stats_server_port) = args.stats_server_port {
+        config_builder.with_stats_server_port(stats_server_port);
+    }
+
+    let config = config_builder.build();
+    let share_chain = InMemoryShareChain::default();
+
+    Ok(Server::new(config, share_chain, shutdown_signal).await?)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+pub use args::Cli;
+
+mod args;
+mod commands;
+mod util;

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -1,0 +1,24 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use clap::builder::styling::AnsiColor;
+use clap::builder::Styles;
+
+pub fn cli_styles() -> Styles {
+    Styles::styled()
+        .header(AnsiColor::BrightYellow.on_default())
+        .usage(AnsiColor::BrightYellow.on_default())
+        .literal(AnsiColor::BrightGreen.on_default())
+        .placeholder(AnsiColor::BrightCyan.on_default())
+        .error(AnsiColor::BrightRed.on_default())
+        .invalid(AnsiColor::BrightRed.on_default())
+        .valid(AnsiColor::BrightGreen.on_default())
+}
+
+pub fn validate_tribe(tribe: &str) -> Result<String, String> {
+    if tribe.trim().is_empty() {
+        return Err(String::from("tribe must be set"));
+    }
+
+    Ok(String::from(tribe))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,14 +130,14 @@ struct Cli {
     base_dir: Option<PathBuf>,
 }
 
-fn validate_tribe(tribe: &str) -> Result<(), String> {
+fn validate_tribe(tribe: &str) -> Result<String, String> {
     if tribe.trim().is_empty() {
         return Err(String::from(
             "tribe must be set",
         ));
     }
 
-    Ok(())
+    Ok(String::from(tribe))
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,280 +1,31 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::env;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
+use clap::Parser;
+use signal_hook::consts::{SIGINT, SIGQUIT, SIGTERM};
+use signal_hook::iterator::Signals;
+use tari_shutdown::Shutdown;
 
-use clap::{
-    builder::{Styles, styling::AnsiColor},
-    Parser, Subcommand,
-};
-use itertools::Itertools;
-use libp2p::futures::SinkExt;
-use libp2p::identity::Keypair;
-use tari_common::configuration::Network;
-use tari_common::initialize_logging;
-use tari_shutdown::{Shutdown, ShutdownSignal};
-use tokio::{select, time};
-use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
+use crate::cli::Cli;
 
-use crate::server::{p2p, Server};
-use crate::server::p2p::peer_store::PeerStore;
-use crate::server::p2p::Tribe;
-use crate::sharechain::in_memory::InMemoryShareChain;
-
+mod cli;
 mod server;
 mod sharechain;
 
-fn cli_styles() -> Styles {
-    Styles::styled()
-        .header(AnsiColor::BrightYellow.on_default())
-        .usage(AnsiColor::BrightYellow.on_default())
-        .literal(AnsiColor::BrightGreen.on_default())
-        .placeholder(AnsiColor::BrightCyan.on_default())
-        .error(AnsiColor::BrightRed.on_default())
-        .invalid(AnsiColor::BrightRed.on_default())
-        .valid(AnsiColor::BrightGreen.on_default())
-}
-
-#[allow(clippy::struct_excessive_bools)]
-#[derive(Clone, Parser, Debug)]
-struct StartArgs {
-    /// (Optional) gRPC port to use.
-    #[arg(short, long, value_name = "grpc-port")]
-    grpc_port: Option<u16>,
-
-    /// (Optional) p2p port to use. It is used to connect p2pool nodes.
-    #[arg(short, long, value_name = "p2p-port")]
-    p2p_port: Option<u16>,
-
-    /// (Optional) stats server port to use.
-    #[arg(long, value_name = "stats-server-port")]
-    stats_server_port: Option<u16>,
-
-    /// (Optional) seed peers.
-    /// Any amount of seed peers can be added to join a p2pool network.
-    ///
-    /// Please note that these addresses must be in libp2p multi address format and must contain peer ID
-    /// or use a dnsaddr multi address!
-    ///
-    /// By default a Tari provided seed peer is added.
-    ///
-    /// e.g.:
-    /// /ip4/127.0.0.1/tcp/52313/p2p/12D3KooWCUNCvi7PBPymgsHx39JWErYdSoT3EFPrn3xoVff4CHFu
-    /// /dnsaddr/esmeralda.p2pool.tari.com
-    #[arg(short, long, value_name = "seed-peers")]
-    seed_peers: Option<Vec<String>>,
-
-    /// If set, Tari provided seed peers will NOT be automatically added to seed peers list.
-    #[arg(long, value_name = "no-default-seed-peers", default_value_t = false)]
-    no_default_seed_peers: bool,
-
-    /// Starts the node as a stable peer.
-    ///
-    /// Identity of the peer will be saved locally (to --private-key-location)
-    /// and ID of the Peer remains the same.
-    #[arg(long, value_name = "stable-peer", default_value_t = false)]
-    stable_peer: bool,
-
-    /// Tribe to enter (a team of miners).
-    /// A tribe can have any name.
-    #[arg(
-        long, value_name = "tribe", default_value = "default", value_parser = validate_tribe
-    )]
-    tribe: String,
-
-    /// Private key folder.
-    ///
-    /// Needs --stable-peer to be set.
-    #[arg(
-        long,
-        value_name = "private-key-folder",
-        requires = "stable_peer",
-        default_value = "."
-    )]
-    private_key_folder: PathBuf,
-
-    /// Mining disabled
-    ///
-    /// In case it is set, the node will only handle p2p operations,
-    /// will be syncing with share chain, but not starting gRPC services and no Tari base node needed.
-    /// By setting this it can be used as a stable node for routing only.
-    #[arg(long, value_name = "mining-disabled", default_value_t = false)]
-    mining_disabled: bool,
-
-    /// mDNS disabled
-    ///
-    /// If set, mDNS local peer discovery is disabled.
-    #[arg(long, value_name = "mdns-disabled", default_value_t = false)]
-    mdns_disabled: bool,
-
-    /// Stats server disabled
-    ///
-    /// If set, local stats HTTP server is disabled.
-    #[arg(long, value_name = "stats-server-disabled", default_value_t = false)]
-    stats_server_disabled: bool,
-}
-
-#[derive(Subcommand, Clone, Debug)]
-enum Commands {
-    /// Starts sha-p2pool node.
-    Start {
-        #[clap(flatten)]
-        args: StartArgs,
-    },
-
-    /// Generating new identity.
-    GenerateIdentity,
-
-    /// Listing all tribes that are present on the network.
-    ListTribes {
-        #[clap(flatten)]
-        args: StartArgs,
-    },
-}
-
-#[derive(Clone, Parser)]
-#[command(version)]
-#[command(styles = cli_styles())]
-#[command(about = "⛏ Decentralized mining pool for Tari network ⛏", long_about = None)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-
-    /// (Optional) base dir.
-    #[arg(short, long, value_name = "base-dir")]
-    base_dir: Option<PathBuf>,
-}
-
-fn validate_tribe(tribe: &str) -> Result<String, String> {
-    if tribe.trim().is_empty() {
-        return Err(String::from("tribe must be set"));
-    }
-
-    Ok(String::from(tribe))
-}
-
-impl Cli {
-    pub fn base_dir(&self) -> PathBuf {
-        self.base_dir
-            .clone()
-            .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/p2pool"))
-    }
-}
-
-async fn server(cli: Arc<Cli>, args: &StartArgs, shutdown_signal: ShutdownSignal, enable_logging: bool)
-                -> anyhow::Result<Server<InMemoryShareChain>> {
-    if enable_logging {
-        // logger setup
-        if let Err(e) = initialize_logging(
-            &cli.base_dir().join("configs/logs.yml"),
-            &cli.base_dir(),
-            include_str!("../log4rs_sample.yml"),
-        ) {
-            eprintln!("{}", e);
-            return Err(e.into());
-        }
-    }
-
-    let mut config_builder = server::Config::builder();
-    if let Some(grpc_port) = args.grpc_port {
-        config_builder.with_grpc_port(grpc_port);
-    }
-    if let Some(p2p_port) = args.p2p_port {
-        config_builder.with_p2p_port(p2p_port);
-    }
-
-    config_builder.with_tribe(Tribe::from(args.tribe.clone()));
-
-    // set default tari network specific seed peer address
-    let mut seed_peers = vec![];
-    let network = Network::get_current_or_user_setting_or_default();
-    if network != Network::LocalNet && !args.no_default_seed_peers {
-        let default_seed_peer = format!("/dnsaddr/{}.p2pool.tari.com", network.as_key_str());
-        seed_peers.push(default_seed_peer);
-    }
-    if let Some(cli_seed_peers) = args.seed_peers.clone() {
-        seed_peers.extend(cli_seed_peers.iter().cloned());
-    }
-    config_builder.with_seed_peers(seed_peers);
-
-    config_builder.with_stable_peer(args.stable_peer);
-    config_builder.with_private_key_folder(args.private_key_folder.clone());
-
-    // try to extract env var based private key
-    if let Ok(identity_cbor) = env::var("SHA_P2POOL_IDENTITY") {
-        let identity_raw = hex::decode(identity_cbor.as_bytes())?;
-        let private_key = Keypair::from_protobuf_encoding(identity_raw.as_slice())?;
-        config_builder.with_private_key(Some(private_key));
-    }
-
-    config_builder.with_mining_enabled(!args.mining_disabled);
-    config_builder.with_mdns_enabled(!args.mdns_disabled);
-    config_builder.with_stats_server_enabled(!args.stats_server_disabled);
-    if let Some(stats_server_port) = args.stats_server_port {
-        config_builder.with_stats_server_port(stats_server_port);
-    }
-
-    let config = config_builder.build();
-    let share_chain = InMemoryShareChain::default();
-
-    Ok(Server::new(config, share_chain, shutdown_signal).await?)
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let shutdown = Shutdown::new();
-    let cli = Cli::parse();
+    // shutdown hook
+    let mut cli_shutdown = Shutdown::new();
+    let cli_shutdown_signal = cli_shutdown.to_signal();
+    let mut signals = Signals::new([SIGINT, SIGTERM, SIGQUIT])?;
+    let signals_handle = signals.handle();
+    tokio::spawn(async move {
+        let _ = signals.forever().next();
+        cli_shutdown.trigger();
+    });
 
-    let cli_ref = Arc::new(cli.clone());
-    match &cli.command {
-        Commands::Start { args } => {
-            server(cli_ref.clone(), args, shutdown.to_signal(), true).await?.start().await?;
-        }
-        Commands::GenerateIdentity => {
-            let result = p2p::util::generate_identity().await?;
-            print!("{}", serde_json::to_value(result)?);
-        }
-        Commands::ListTribes { args } => {
-            // start server asynchronously
-            let cli_ref = cli_ref.clone();
-            let mut args_clone = args.clone();
-            args_clone.mining_disabled = true;
-            let shutdown_signal = shutdown.to_signal();
-            let (peer_store_channel_tx, peer_store_channel_rx) =
-                oneshot::channel::<Arc<PeerStore>>();
-            let handle: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
-                let mut server = server(cli_ref, &args_clone, shutdown_signal, false).await?;
-                let _ = peer_store_channel_tx.send(server.p2p_service().network_peer_store().clone());
-                server.start().await?;
-                Ok(())
-            });
-
-            // wait for peer store from started server
-            let peer_store = peer_store_channel_rx.await?;
-
-            // collect tribes for 30 seconds
-            let mut tribes = vec![];
-            let timeout = time::sleep(Duration::from_secs(30));
-            tokio::pin!(timeout);
-            loop {
-                select! {
-                    () = &mut timeout => {
-                        break;
-                    }
-                    current_tribes = peer_store.tribes() => {
-                        tribes = current_tribes;
-                    }
-                }
-            }
-            handle.abort();
-            let tribes = tribes.iter().map(|tribe| tribe.to_string()).collect_vec();
-            print!("{}", serde_json::to_value(tribes)?);
-        }
-    }
-
+    // cli
+    Cli::parse().handle_command(cli_shutdown_signal).await?;
+    signals_handle.close();
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@
 use std::env;
 use std::path::PathBuf;
 
-use clap::{builder::{Styles, styling::AnsiColor}, Parser, Subcommand};
+use clap::{
+    builder::{styling::AnsiColor, Styles},
+    Parser, Subcommand,
+};
 use libp2p::identity::Keypair;
 use tari_common::configuration::Network;
 use tari_common::initialize_logging;
@@ -136,9 +139,7 @@ struct Cli {
 
 fn validate_tribe(tribe: &str) -> Result<String, String> {
     if tribe.trim().is_empty() {
-        return Err(String::from(
-            "tribe must be set",
-        ));
+        return Err(String::from("tribe must be set"));
     }
 
     Ok(String::from(tribe))
@@ -219,12 +220,12 @@ async fn main() -> anyhow::Result<()> {
     match &cli.command {
         Commands::Start { args } => {
             start(cli_ref, args).await?;
-        }
+        },
         Commands::GenerateIdentity => {
             let result = p2p::util::generate_identity().await?;
             print!("{}", serde_json::to_value(result)?);
-        }
-        Commands::ListTribes => {}
+        },
+        Commands::ListTribes => {},
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ struct StartArgs {
     #[arg(short, long, value_name = "seed-peers")]
     seed_peers: Option<Vec<String>>,
 
+    /// If set, Tari provided seed peers will NOT be automatically added to seed peers list.
+    #[arg(long, value_name = "no_default_seed_peers", default_value_t = false)]
+    no_default_seed_peers: bool,
+
     /// Starts the node as a stable peer.
     ///
     /// Identity of the peer will be saved locally (to --private-key-location)
@@ -172,7 +176,7 @@ async fn start(cli: &Cli, args: &StartArgs) -> anyhow::Result<()> {
     // set default tari network specific seed peer address
     let mut seed_peers = vec![];
     let network = Network::get_current_or_user_setting_or_default();
-    if network != Network::LocalNet {
+    if network != Network::LocalNet && !args.no_default_seed_peers {
         let default_seed_peer = format!("/dnsaddr/{}.p2pool.tari.com", network.as_key_str());
         seed_peers.push(default_seed_peer);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use tari_common::configuration::Network;
 use tari_common::initialize_logging;
 
 use crate::server::p2p;
+use crate::server::p2p::Tribe;
 use crate::sharechain::in_memory::InMemoryShareChain;
 
 mod server;
@@ -179,8 +180,8 @@ async fn main() -> anyhow::Result<()> {
     if let Some(stats_server_port) = cli.stats_server_port {
         config_builder.with_stats_server_port(stats_server_port);
     }
-    // TODO: implement tribe struct for general parsing (converting any string to snake_case string)
-    config_builder.with_tribe(cli.tribe);
+    // TODO: check for empty tribe
+    config_builder.with_tribe(Tribe::from(cli.tribe));
 
     // server start
     let config = config_builder.build();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::path::PathBuf;
 
 use clap::{
-    builder::{styling::AnsiColor, Styles},
+    builder::{Styles, styling::AnsiColor},
     Parser,
 };
 use libp2p::identity::Keypair;
@@ -59,7 +59,7 @@ struct Cli {
     ///
     /// e.g.:
     /// /ip4/127.0.0.1/tcp/52313/p2p/12D3KooWCUNCvi7PBPymgsHx39JWErYdSoT3EFPrn3xoVff4CHFu
-    /// /dnsaddr/esme.p2pool.tari.com
+    /// /dnsaddr/esmeralda.p2pool.tari.com
     #[arg(short, long, value_name = "seed-peers")]
     seed_peers: Option<Vec<String>>,
 
@@ -69,6 +69,11 @@ struct Cli {
     /// and ID of the Peer remains the same.
     #[arg(long, value_name = "stable-peer", default_value_t = false)]
     stable_peer: bool,
+
+    /// Tribe to enter (a team of miners).
+    /// A tribe can have any name.
+    #[arg(long, value_name = "tribe", default_value = "default")]
+    tribe: String,
 
     /// Private key folder.
     ///
@@ -174,6 +179,8 @@ async fn main() -> anyhow::Result<()> {
     if let Some(stats_server_port) = cli.stats_server_port {
         config_builder.with_stats_server_port(stats_server_port);
     }
+    // TODO: implement tribe struct for general parsing (converting any string to snake_case string)
+    config_builder.with_tribe(cli.tribe);
 
     // server start
     let config = config_builder.build();

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ struct StartArgs {
     seed_peers: Option<Vec<String>>,
 
     /// If set, Tari provided seed peers will NOT be automatically added to seed peers list.
-    #[arg(long, value_name = "no_default_seed_peers", default_value_t = false)]
+    #[arg(long, value_name = "no-default-seed-peers", default_value_t = false)]
     no_default_seed_peers: bool,
 
     /// Starts the node as a stable peer.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -5,9 +5,9 @@ use std::{path::PathBuf, time::Duration};
 
 use libp2p::identity::Keypair;
 
-use crate::server::{p2p, p2p::peer_store::PeerStoreConfig};
 use crate::server::http::stats;
 use crate::server::p2p::Tribe;
+use crate::server::{p2p, p2p::peer_store::PeerStoreConfig};
 
 /// Config is the server configuration struct.
 #[derive(Clone)]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -5,8 +5,8 @@ use std::{path::PathBuf, time::Duration};
 
 use libp2p::identity::Keypair;
 
-use crate::server::http::stats;
 use crate::server::{p2p, p2p::peer_store::PeerStoreConfig};
+use crate::server::http::stats;
 
 /// Config is the server configuration struct.
 #[derive(Clone)]
@@ -62,6 +62,11 @@ impl ConfigBuilder {
 
     pub fn with_idle_connection_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.config.idle_connection_timeout = timeout;
+        self
+    }
+
+    pub fn with_tribe(&mut self, tribe: String) -> &mut Self {
+        self.config.p2p_service.tribe = tribe;
         self
     }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -7,6 +7,7 @@ use libp2p::identity::Keypair;
 
 use crate::server::{p2p, p2p::peer_store::PeerStoreConfig};
 use crate::server::http::stats;
+use crate::server::p2p::Tribe;
 
 /// Config is the server configuration struct.
 #[derive(Clone)]
@@ -65,7 +66,7 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn with_tribe(&mut self, tribe: String) -> &mut Self {
+    pub fn with_tribe(&mut self, tribe: Tribe) -> &mut Self {
         self.config.p2p_service.tribe = tribe;
         self
     }

--- a/src/server/p2p/messages.rs
+++ b/src/server/p2p/messages.rs
@@ -6,8 +6,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 
-use crate::{server::p2p::Error, sharechain::block::Block};
 use crate::server::p2p::Tribe;
+use crate::{server::p2p::Error, sharechain::block::Block};
 
 #[macro_export]
 macro_rules! impl_conversions {

--- a/src/server/p2p/messages.rs
+++ b/src/server/p2p/messages.rs
@@ -7,6 +7,7 @@ use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 
 use crate::{server::p2p::Error, sharechain::block::Block};
+use crate::server::p2p::Tribe;
 
 #[macro_export]
 macro_rules! impl_conversions {
@@ -42,17 +43,19 @@ where
     serde_cbor::to_vec(input).map_err(Error::SerializeDeserialize)
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerInfo {
     pub current_height: u64,
-    timestamp: u128,
+    pub tribe: Tribe,
+    pub timestamp: u128,
 }
 impl_conversions!(PeerInfo);
 impl PeerInfo {
-    pub fn new(current_height: u64) -> Self {
+    pub fn new(current_height: u64, tribe: Tribe) -> Self {
         let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_micros();
         Self {
             current_height,
+            tribe,
             timestamp,
         }
     }

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -32,6 +32,8 @@ use libp2p::{
 };
 use libp2p::swarm::behaviour::toggle::Toggle;
 use log::{debug, error, info, warn};
+use log::kv::{ToValue, Value};
+use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_utilities::hex::Hex;
 use tokio::{
@@ -62,9 +64,15 @@ const SHARE_CHAIN_SYNC_REQ_RESP_PROTOCOL: &str = "/share_chain_sync/1";
 const LOG_TARGET: &str = "p2pool::server::p2p";
 pub const STABLE_PRIVATE_KEY_FILE: &str = "p2pool_private.key";
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Tribe {
     inner: String,
+}
+
+impl ToValue for Tribe {
+    fn to_value(&self) -> Value {
+        Value::from(self.inner.as_str())
+    }
 }
 
 impl From<String> for Tribe {
@@ -123,7 +131,8 @@ where
     swarm: Swarm<ServerNetworkBehaviour>,
     port: u16,
     share_chain: Arc<S>,
-    peer_store: Arc<PeerStore>,
+    tribe_peer_store: Arc<PeerStore>,
+    network_peer_store: Arc<PeerStore>,
     config: Config,
     sync_in_progress: Arc<AtomicBool>,
     share_chain_sync_tx: broadcast::Sender<LocalShareChainSyncRequest>,
@@ -144,7 +153,8 @@ where
     pub async fn new(
         config: &config::Config,
         share_chain: Arc<S>,
-        peer_store: Arc<PeerStore>,
+        tribe_peer_store: Arc<PeerStore>,
+        network_peer_store: Arc<PeerStore>,
         sync_in_progress: Arc<AtomicBool>,
     ) -> Result<Self, Error> {
         let swarm = Self::new_swarm(config).await?;
@@ -157,7 +167,8 @@ where
             swarm,
             port: config.p2p_port,
             share_chain,
-            peer_store,
+            tribe_peer_store,
+            network_peer_store,
             config: config.p2p_service.clone(),
             client_broadcast_block_tx: broadcast_block_tx,
             client_broadcast_block_rx: broadcast_block_rx,
@@ -282,20 +293,21 @@ where
         // get peer info
         let share_chain = self.share_chain.clone();
         let current_height = share_chain.tip_height().await.map_err(Error::ShareChain)?;
-        let peer_info_raw: Vec<u8> = PeerInfo::new(current_height).try_into()?;
+        let peer_info_network_raw: Vec<u8> = PeerInfo::new(current_height, self.config.tribe.clone()).try_into()?;
+        let peer_info_tribe_raw: Vec<u8> = PeerInfo::new(current_height, self.config.tribe.clone()).try_into()?;
 
         // broadcast peer info to network
         self.swarm
             .behaviour_mut()
             .gossipsub
-            .publish(IdentTopic::new(Self::network_topic(PEER_INFO_TOPIC)), peer_info_raw.clone())
+            .publish(IdentTopic::new(Self::network_topic(PEER_INFO_TOPIC)), peer_info_network_raw.clone())
             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))?;
 
         // broadcast peer info to tribe
         self.swarm
             .behaviour_mut()
             .gossipsub
-            .publish(IdentTopic::new(Self::tribe_topic(&self.config.tribe, PEER_INFO_TOPIC)), peer_info_raw)
+            .publish(IdentTopic::new(Self::tribe_topic(&self.config.tribe, PEER_INFO_TOPIC)), peer_info_tribe_raw)
             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))?;
 
         Ok(())
@@ -321,16 +333,16 @@ where
                         {
                             Ok(_) => {}
                             Err(error) => {
-                                error!(target: LOG_TARGET, "Failed to broadcast new block: {error:?}")
+                                error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to broadcast new block: {error:?}")
                             }
                         }
                     }
                     Err(error) => {
-                        error!(target: LOG_TARGET, "Failed to convert block to bytes: {error:?}")
+                        error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to convert block to bytes: {error:?}")
                     }
                 }
             }
-            Err(error) => error!(target: LOG_TARGET, "Failed to receive new block: {error:?}"),
+            Err(error) => error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to receive new block: {error:?}"),
         }
     }
 
@@ -381,11 +393,20 @@ where
         let topic = message.topic.to_string();
 
         match topic {
+            topic if topic == Self::network_topic(PEER_INFO_TOPIC) => match messages::PeerInfo::try_from(message) {
+                Ok(payload) => {
+                    debug!(target: LOG_TARGET, tribe = &self.config.tribe; "[NETWORK] New peer info: {peer:?} -> {payload:?}");
+                    self.network_peer_store.add(peer, payload).await;
+                }
+                Err(error) => {
+                    error!(target: LOG_TARGET, tribe = &self.config.tribe; "Can't deserialize peer info payload: {:?}", error);
+                }
+            },
             topic if topic == Self::tribe_topic(&self.config.tribe, PEER_INFO_TOPIC) => match messages::PeerInfo::try_from(message) {
                 Ok(payload) => {
-                    debug!(target: LOG_TARGET, "New peer info: {peer:?} -> {payload:?}");
-                    self.peer_store.add(peer, payload).await;
-                    if let Some(tip) = self.peer_store.tip_of_block_height().await {
+                    debug!(target: LOG_TARGET, tribe = &self.config.tribe; "[TRIBE] New peer info: {peer:?} -> {payload:?}");
+                    self.tribe_peer_store.add(peer, payload).await;
+                    if let Some(tip) = self.tribe_peer_store.tip_of_block_height().await {
                         if let Ok(curr_height) = self.share_chain.tip_height().await {
                             if curr_height < tip.height {
                                 self.sync_share_chain().await;
@@ -394,7 +415,7 @@ where
                     }
                 }
                 Err(error) => {
-                    error!(target: LOG_TARGET, "Can't deserialize peer info payload: {:?}", error);
+                    error!(target: LOG_TARGET, tribe = &self.config.tribe; "Can't deserialize peer info payload: {:?}", error);
                 }
             },
             // TODO: send a signature that proves that the actual block was coming from this peer
@@ -406,7 +427,7 @@ where
 
                 match Block::try_from(message) {
                     Ok(payload) => {
-                        info!(target: LOG_TARGET,"🆕 New block from broadcast: {:?}", &payload.hash().to_hex());
+                        info!(target: LOG_TARGET, tribe = &self.config.tribe; "🆕 New block from broadcast: {:?}", &payload.hash().to_hex());
                         match self.share_chain.submit_block(&payload).await {
                             Ok(result) => {
                                 if result.need_sync {
@@ -414,17 +435,17 @@ where
                                 }
                             }
                             Err(error) => {
-                                error!(target: LOG_TARGET, "Could not add new block to local share chain: {error:?}");
+                                error!(target: LOG_TARGET, tribe = &self.config.tribe; "Could not add new block to local share chain: {error:?}");
                             }
                         }
                     }
                     Err(error) => {
-                        error!(target: LOG_TARGET, "Can't deserialize broadcast block payload: {:?}", error);
+                        error!(target: LOG_TARGET, tribe = &self.config.tribe; "Can't deserialize broadcast block payload: {:?}", error);
                     }
                 }
             }
             _ => {
-                warn!(target: LOG_TARGET, "Unknown topic {topic:?}!");
+                warn!(target: LOG_TARGET, tribe = &self.config.tribe; "Unknown topic {topic:?}!");
             }
         }
     }
@@ -435,7 +456,7 @@ where
         channel: ResponseChannel<ShareChainSyncResponse>,
         request: ShareChainSyncRequest,
     ) {
-        debug!(target: LOG_TARGET, "Incoming Share chain sync request: {request:?}");
+        debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Incoming Share chain sync request: {request:?}");
         match self.share_chain.blocks(request.from_height).await {
             Ok(blocks) => {
                 if self
@@ -445,10 +466,10 @@ where
                     .send_response(channel, ShareChainSyncResponse::new(blocks.clone()))
                     .is_err()
                 {
-                    error!(target: LOG_TARGET, "Failed to send block sync response");
+                    error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to send block sync response");
                 }
             }
-            Err(error) => error!(target: LOG_TARGET, "Failed to get blocks from height: {error:?}"),
+            Err(error) => error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to get blocks from height: {error:?}"),
         }
     }
 
@@ -458,7 +479,7 @@ where
         if self.sync_in_progress.load(Ordering::SeqCst) {
             self.sync_in_progress.store(false, Ordering::SeqCst);
         }
-        debug!(target: LOG_TARGET, "Share chain sync response: {response:?}");
+        debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Share chain sync response: {response:?}");
         match self.share_chain.submit_blocks(response.blocks, true).await {
             Ok(result) => {
                 if result.need_sync {
@@ -466,7 +487,7 @@ where
                 }
             }
             Err(error) => {
-                error!(target: LOG_TARGET, "Failed to add synced blocks to share chain: {error:?}");
+                error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to add synced blocks to share chain: {error:?}");
             }
         }
     }
@@ -475,16 +496,15 @@ where
     /// Note: this is a "stop-the-world" operation, many operations are skipped when synchronizing.
     async fn sync_share_chain(&mut self) {
         if self.sync_in_progress.load(Ordering::SeqCst) {
-            debug!("Sync already in progress...");
             return;
         }
         self.sync_in_progress.store(true, Ordering::SeqCst);
 
-        debug!(target: LOG_TARGET, "Syncing share chain...");
-        match self.peer_store.tip_of_block_height().await {
+        debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Syncing share chain...");
+        match self.tribe_peer_store.tip_of_block_height().await {
             Some(result) => {
-                debug!(target: LOG_TARGET, "Found highest known block height: {result:?}");
-                debug!(target: LOG_TARGET, "Send share chain sync request: {result:?}");
+                debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Found highest known block height: {result:?}");
+                debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Send share chain sync request: {result:?}");
                 // we always send from_height as zero now, to not miss any blocks
                 self.swarm
                     .behaviour_mut()
@@ -493,7 +513,7 @@ where
             }
             None => {
                 self.sync_in_progress.store(false, Ordering::SeqCst);
-                error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
+                error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to get peer with highest share chain height!")
             }
         }
     }
@@ -507,8 +527,9 @@ where
         share_chain: Arc<S>,
         share_chain_sync_tx: broadcast::Sender<LocalShareChainSyncRequest>,
         timeout: Duration,
+        tribe: Tribe,
     ) {
-        info!(target: LOG_TARGET, "Initially syncing share chain (timeout: {timeout:?})...");
+        info!(target: LOG_TARGET, tribe = &tribe; "Initially syncing share chain (timeout: {timeout:?})...");
         in_progress.store(true, Ordering::SeqCst);
         let start = Instant::now();
         loop {
@@ -525,7 +546,7 @@ where
         } // wait for the first height
         match peer_store.tip_of_block_height().await {
             Some(result) => {
-                debug!(target: LOG_TARGET, "Found highest block height: {result:?}");
+                info!(target: LOG_TARGET, tribe = &tribe; "Found highest block height: {result:?}");
                 match share_chain.tip_height().await {
                     Ok(tip) => {
                         if tip < result.height {
@@ -533,7 +554,7 @@ where
                                 result.peer_id,
                                 ShareChainSyncRequest::new(0),
                             )) {
-                                error!("Failed to send share chain sync request: {error:?}");
+                                error!(target: LOG_TARGET, tribe = &tribe; "Failed to send share chain sync request: {error:?}");
                             }
                         } else {
                             in_progress.store(false, Ordering::SeqCst);
@@ -541,13 +562,13 @@ where
                     }
                     Err(error) => {
                         in_progress.store(false, Ordering::SeqCst);
-                        error!(target: LOG_TARGET, "Failed to get latest height of share chain: {error:?}")
+                        error!(target: LOG_TARGET, tribe = &tribe; "Failed to get latest height of share chain: {error:?}")
                     }
                 }
             }
             None => {
                 in_progress.store(false, Ordering::SeqCst);
-                error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
+                error!(target: LOG_TARGET, tribe = &tribe; "Failed to get peer with highest share chain height!")
             }
         }
     }
@@ -556,7 +577,7 @@ where
     async fn handle_event(&mut self, event: SwarmEvent<ServerNetworkBehaviourEvent>) {
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
-                info!(target: LOG_TARGET, "Listening on {address:?}");
+                info!(target: LOG_TARGET, tribe = &self.config.tribe; "Listening on {address:?}");
             }
             SwarmEvent::Behaviour(event) => match event {
                 ServerNetworkBehaviourEvent::Mdns(mdns_event) => match mdns_event {
@@ -604,13 +625,13 @@ where
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
-                        error!(target: LOG_TARGET, "REQ-RES outbound failure: {peer:?} -> {error:?}");
+                        error!(target: LOG_TARGET, tribe = &self.config.tribe; "REQ-RES outbound failure: {peer:?} -> {error:?}");
                     }
                     request_response::Event::InboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
-                        error!(target: LOG_TARGET, "REQ-RES inbound failure: {peer:?} -> {error:?}");
+                        error!(target: LOG_TARGET, tribe = &self.config.tribe; "REQ-RES inbound failure: {peer:?} -> {error:?}");
                     }
                     request_response::Event::ResponseSent { .. } => {}
                 },
@@ -629,7 +650,7 @@ where
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&old_peer);
                         }
                     }
-                    _ => debug!(target: LOG_TARGET, "[KADEMLIA] {event:?}"),
+                    _ => debug!(target: LOG_TARGET, tribe = &self.config.tribe; "[KADEMLIA] {event:?}"),
                 },
             },
             _ => {}
@@ -651,22 +672,22 @@ where
                 }
                 _ = publish_peer_info_interval.tick() => {
                     // handle case when we have some peers removed
-                    let expired_peers = self.peer_store.cleanup().await;
+                    let expired_peers = self.tribe_peer_store.cleanup().await;
                     for exp_peer in expired_peers {
                         self.swarm.behaviour_mut().kademlia.remove_peer(&exp_peer);
                         self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&exp_peer);
                     }
 
                     // broadcast peer info
-                    debug!(target: LOG_TARGET, "Peer count: {:?}", self.peer_store.peer_count().await);
+                    debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Peer count: {:?}", self.tribe_peer_store.peer_count().await);
                     if let Err(error) = self.broadcast_peer_info().await {
                         match error {
                             Error::LibP2P(LibP2PError::Publish(PublishError::InsufficientPeers)) => {
-                                warn!(target: LOG_TARGET, "No peers to broadcast peer info!");
+                                warn!(target: LOG_TARGET, tribe = &self.config.tribe; "No peers to broadcast peer info!");
                             }
                             Error::LibP2P(LibP2PError::Publish(PublishError::Duplicate)) => {}
                             _ => {
-                                error!(target: LOG_TARGET, "Failed to publish node info: {error:?}");
+                                error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to publish node info: {error:?}");
                             }
                         }
                     }
@@ -684,7 +705,7 @@ where
                 },
                 _ = kademlia_bootstrap_interval.tick() => {
                     if let Err(error) = self.bootstrap_kademlia() {
-                        warn!("Failed to do kademlia bootstrap: {error:?}");
+                        warn!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to do kademlia bootstrap: {error:?}");
                     }
                 }
             }
@@ -736,14 +757,14 @@ where
                                             }
                                         }
                                         Err(error) => {
-                                            warn!("Skipping invalid DNS entry: {:?}: {error:?}", chars);
+                                            warn!(target: LOG_TARGET, tribe = &self.config.tribe; "Skipping invalid DNS entry: {:?}: {error:?}", chars);
                                         }
                                     }
                                 }
                             }
                         }
                         Err(error) => {
-                            error!("Failed to lookup domain records: {error:?}");
+                            error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to lookup domain records: {error:?}");
                         }
                     }
                 }
@@ -795,9 +816,10 @@ where
 
         // start initial share chain sync
         let in_progress = self.sync_in_progress.clone();
-        let peer_store = self.peer_store.clone();
+        let peer_store = self.tribe_peer_store.clone();
         let share_chain = self.share_chain.clone();
         let share_chain_sync_tx = self.share_chain_sync_tx.clone();
+        let tribe = self.config.tribe.clone();
         tokio::spawn(async move {
             Self::initial_share_chain_sync(
                 in_progress,
@@ -805,6 +827,7 @@ where
                 share_chain,
                 share_chain_sync_tx,
                 Duration::from_secs(30),
+                tribe,
             )
                 .await;
         });

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -7,9 +7,11 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use std::fmt::Display;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
+use convert_case::{Case, Casing};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::TokioAsyncResolver;
 use itertools::Itertools;
@@ -61,10 +63,29 @@ const LOG_TARGET: &str = "p2pool::server::p2p";
 pub const STABLE_PRIVATE_KEY_FILE: &str = "p2pool_private.key";
 
 #[derive(Clone, Debug)]
+pub struct Tribe {
+    inner: String,
+}
+
+impl From<String> for Tribe {
+    fn from(value: String) -> Self {
+        Self {
+            inner: value.to_case(Case::Snake)
+        }
+    }
+}
+
+impl Display for Tribe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct Config {
     pub seed_peers: Vec<String>,
     pub peer_info_publish_interval: Duration,
-    pub tribe: String,
+    pub tribe: Tribe,
     pub stable_peer: bool,
     pub private_key_folder: PathBuf,
     pub private_key: Option<Keypair>,

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -1,34 +1,34 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
     path::PathBuf,
     sync::Arc,
     time::Duration,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::TokioAsyncResolver;
 use itertools::Itertools;
-use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
     futures::StreamExt,
     gossipsub,
     gossipsub::{IdentTopic, Message, PublishError},
     identity::Keypair,
     kad,
-    kad::{store::MemoryStore, Event, Mode},
+    kad::{Event, Mode, store::MemoryStore},
     mdns,
     mdns::tokio::Tokio,
-    multiaddr::Protocol,
-    noise, request_response,
+    Multiaddr,
+    multiaddr::Protocol, noise,
+    request_response,
     request_response::{cbor, ResponseChannel},
-    swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, StreamProtocol, Swarm,
+    StreamProtocol, swarm::{NetworkBehaviour, SwarmEvent}, Swarm, tcp, yamux,
 };
+use libp2p::swarm::behaviour::toggle::Toggle;
 use log::{debug, error, info, warn};
 use tari_common::configuration::Network;
 use tari_utilities::hex::Hex;
@@ -40,19 +40,19 @@ use tokio::{
     sync::{broadcast, broadcast::error::RecvError},
 };
 
-use crate::server::p2p::messages::LocalShareChainSyncRequest;
 use crate::{
     server::{
         config,
         p2p::{
+            Error,
+            LibP2PError,
             messages,
-            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse},
-            peer_store::PeerStore,
-            Error, LibP2PError, ServiceClient,
+            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse}, peer_store::PeerStore, ServiceClient,
         },
     },
     sharechain::{block::Block, ShareChain},
 };
+use crate::server::p2p::messages::LocalShareChainSyncRequest;
 
 const PEER_INFO_TOPIC: &str = "peer_info";
 const NEW_BLOCK_TOPIC: &str = "new_block";
@@ -64,6 +64,7 @@ pub const STABLE_PRIVATE_KEY_FILE: &str = "p2pool_private.key";
 pub struct Config {
     pub seed_peers: Vec<String>,
     pub peer_info_publish_interval: Duration,
+    pub tribe: String,
     pub stable_peer: bool,
     pub private_key_folder: PathBuf,
     pub private_key: Option<Keypair>,
@@ -75,6 +76,7 @@ impl Default for Config {
         Self {
             seed_peers: vec![],
             peer_info_publish_interval: Duration::from_secs(5),
+            tribe: "default".to_string(),
             stable_peer: false,
             private_key_folder: PathBuf::from("."),
             private_key: None,
@@ -261,11 +263,18 @@ where
         let current_height = share_chain.tip_height().await.map_err(Error::ShareChain)?;
         let peer_info_raw: Vec<u8> = PeerInfo::new(current_height).try_into()?;
 
-        // broadcast peer info
+        // broadcast peer info to network
         self.swarm
             .behaviour_mut()
             .gossipsub
-            .publish(IdentTopic::new(Self::topic_name(PEER_INFO_TOPIC)), peer_info_raw)
+            .publish(IdentTopic::new(Self::network_topic(PEER_INFO_TOPIC)), peer_info_raw)
+            .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))?;
+
+        // broadcast peer info to tribe
+        self.swarm
+            .behaviour_mut()
+            .gossipsub
+            .publish(IdentTopic::new(Self::tribe_topic(self.config.tribe.as_str(), PEER_INFO_TOPIC)), peer_info_raw)
             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))?;
 
         Ok(())
@@ -286,44 +295,61 @@ where
                             .swarm
                             .behaviour_mut()
                             .gossipsub
-                            .publish(IdentTopic::new(Self::topic_name(NEW_BLOCK_TOPIC)), block_raw)
+                            .publish(IdentTopic::new(Self::network_topic(NEW_BLOCK_TOPIC)), block_raw)
                             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))
                         {
-                            Ok(_) => {},
+                            Ok(_) => {}
                             Err(error) => {
                                 error!(target: LOG_TARGET, "Failed to broadcast new block: {error:?}")
-                            },
+                            }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, "Failed to convert block to bytes: {error:?}")
-                    },
+                    }
                 }
-            },
+            }
             Err(error) => error!(target: LOG_TARGET, "Failed to receive new block: {error:?}"),
         }
     }
 
-    /// Generates the gossip sub topic names based on the current Tari network to avoid mixing up
+    /// Generates a gossip sub topic name based on the current Tari network to avoid mixing up
     /// blocks and peers with different Tari networks.
-    fn topic_name(topic: &str) -> String {
+    fn network_topic(topic: &str) -> String {
         let network = Network::get_current_or_user_setting_or_default().as_key_str();
         format!("{network}_{topic}")
     }
 
+    /// Generates a gossip sub topic name based on the current Tari network to avoid mixing up
+    /// blocks and peers with different Tari networks and the given tribe name.
+    fn tribe_topic(tribe: &str, topic: &str) -> String {
+        let network = Network::get_current_or_user_setting_or_default().as_key_str();
+        format!("{network}_{tribe}_{topic}")
+    }
+
     /// Subscribing to a gossipsub topic.
-    fn subscribe(&mut self, topic: &str) {
+    fn subscribe(&mut self, topic: &str, tribe: Option<&str>) {
+        let topic = match tribe {
+            Some(tribe) => {
+                Self::tribe_topic(tribe, topic)
+            }
+            None => {
+                Self::network_topic(topic)
+            }
+        };
         self.swarm
             .behaviour_mut()
             .gossipsub
-            .subscribe(&IdentTopic::new(Self::topic_name(topic)))
+            .subscribe(&IdentTopic::new(topic))
             .expect("must be subscribed to topic");
     }
 
     /// Subscribes to all topics we need.
     fn subscribe_to_topics(&mut self) {
-        self.subscribe(PEER_INFO_TOPIC);
-        self.subscribe(NEW_BLOCK_TOPIC);
+        let tribe = self.config.tribe.clone();
+        self.subscribe(PEER_INFO_TOPIC, Some(tribe.as_str()));
+        self.subscribe(PEER_INFO_TOPIC, None);
+        self.subscribe(NEW_BLOCK_TOPIC, None);
     }
 
     /// Main method to handle any message comes from gossipsub.
@@ -338,7 +364,7 @@ where
         let topic = message.topic.to_string();
 
         match topic {
-            topic if topic == Self::topic_name(PEER_INFO_TOPIC) => match messages::PeerInfo::try_from(message) {
+            topic if topic == Self::network_topic(PEER_INFO_TOPIC) => match messages::PeerInfo::try_from(message) {
                 Ok(payload) => {
                     debug!(target: LOG_TARGET, "New peer info: {peer:?} -> {payload:?}");
                     self.peer_store.add(peer, payload).await;
@@ -349,14 +375,14 @@ where
                             }
                         }
                     }
-                },
+                }
                 Err(error) => {
                     error!(target: LOG_TARGET, "Can't deserialize peer info payload: {:?}", error);
-                },
+                }
             },
             // TODO: send a signature that proves that the actual block was coming from this peer
             // TODO: (sender peer's wallet address should be included always in the conibases with a fixed percent (like 20%))
-            topic if topic == Self::topic_name(NEW_BLOCK_TOPIC) => {
+            topic if topic == Self::network_topic(NEW_BLOCK_TOPIC) => {
                 if self.sync_in_progress.load(Ordering::SeqCst) {
                     return;
                 }
@@ -369,20 +395,20 @@ where
                                 if result.need_sync {
                                     self.sync_share_chain().await;
                                 }
-                            },
+                            }
                             Err(error) => {
                                 error!(target: LOG_TARGET, "Could not add new block to local share chain: {error:?}");
-                            },
+                            }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, "Can't deserialize broadcast block payload: {:?}", error);
-                    },
+                    }
                 }
-            },
+            }
             _ => {
                 warn!(target: LOG_TARGET, "Unknown topic {topic:?}!");
-            },
+            }
         }
     }
 
@@ -404,7 +430,7 @@ where
                 {
                     error!(target: LOG_TARGET, "Failed to send block sync response");
                 }
-            },
+            }
             Err(error) => error!(target: LOG_TARGET, "Failed to get blocks from height: {error:?}"),
         }
     }
@@ -421,10 +447,10 @@ where
                 if result.need_sync {
                     self.sync_share_chain().await;
                 }
-            },
+            }
             Err(error) => {
                 error!(target: LOG_TARGET, "Failed to add synced blocks to share chain: {error:?}");
-            },
+            }
         }
     }
 
@@ -447,11 +473,11 @@ where
                     .behaviour_mut()
                     .share_chain_sync
                     .send_request(&result.peer_id, ShareChainSyncRequest::new(0));
-            },
+            }
             None => {
                 self.sync_in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
-            },
+            }
         }
     }
 
@@ -495,17 +521,17 @@ where
                         } else {
                             in_progress.store(false, Ordering::SeqCst);
                         }
-                    },
+                    }
                     Err(error) => {
                         in_progress.store(false, Ordering::SeqCst);
                         error!(target: LOG_TARGET, "Failed to get latest height of share chain: {error:?}")
-                    },
+                    }
                 }
-            },
+            }
             None => {
                 in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, "Failed to get peer with highest share chain height!")
-            },
+            }
         }
     }
 
@@ -514,7 +540,7 @@ where
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(target: LOG_TARGET, "Listening on {address:?}");
-            },
+            }
             SwarmEvent::Behaviour(event) => match event {
                 ServerNetworkBehaviourEvent::Mdns(mdns_event) => match mdns_event {
                     mdns::Event::Discovered(peers) => {
@@ -522,12 +548,12 @@ where
                             self.swarm.add_peer_address(peer, addr);
                             self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer);
                         }
-                    },
+                    }
                     mdns::Event::Expired(peers) => {
                         for (peer, _addr) in peers {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&peer);
                         }
-                    },
+                    }
                 },
                 ServerNetworkBehaviourEvent::Gossipsub(event) => match event {
                     gossipsub::Event::Message {
@@ -536,10 +562,10 @@ where
                         propagation_source: _propagation_source,
                     } => {
                         self.handle_new_gossipsub_message(message).await;
-                    },
-                    gossipsub::Event::Subscribed { .. } => {},
-                    gossipsub::Event::Unsubscribed { .. } => {},
-                    gossipsub::Event::GossipsubNotSupported { .. } => {},
+                    }
+                    gossipsub::Event::Subscribed { .. } => {}
+                    gossipsub::Event::Unsubscribed { .. } => {}
+                    gossipsub::Event::GossipsubNotSupported { .. } => {}
                 },
                 ServerNetworkBehaviourEvent::ShareChainSync(event) => match event {
                     request_response::Event::Message { peer: _peer, message } => match message {
@@ -549,27 +575,27 @@ where
                             channel,
                         } => {
                             self.handle_share_chain_sync_request(channel, request).await;
-                        },
+                        }
                         request_response::Message::Response {
                             request_id: _request_id,
                             response,
                         } => {
                             self.handle_share_chain_sync_response(response).await;
-                        },
+                        }
                     },
                     request_response::Event::OutboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, "REQ-RES outbound failure: {peer:?} -> {error:?}");
-                    },
+                    }
                     request_response::Event::InboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, "REQ-RES inbound failure: {peer:?} -> {error:?}");
-                    },
-                    request_response::Event::ResponseSent { .. } => {},
+                    }
+                    request_response::Event::ResponseSent { .. } => {}
                 },
                 ServerNetworkBehaviourEvent::Kademlia(event) => match event {
                     Event::RoutingUpdated {
@@ -585,11 +611,11 @@ where
                         if let Some(old_peer) = old_peer {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&old_peer);
                         }
-                    },
+                    }
                     _ => debug!(target: LOG_TARGET, "[KADEMLIA] {event:?}"),
                 },
             },
-            _ => {},
+            _ => {}
         };
     }
 
@@ -691,17 +717,17 @@ where
                                             if let Some(peer_id) = peer_id {
                                                 self.swarm.behaviour_mut().kademlia.add_address(&peer_id, parsed_addr);
                                             }
-                                        },
+                                        }
                                         Err(error) => {
                                             warn!("Skipping invalid DNS entry: {:?}: {error:?}", chars);
-                                        },
+                                        }
                                     }
                                 }
                             }
-                        },
+                        }
                         Err(error) => {
                             error!("Failed to lookup domain records: {error:?}");
-                        },
+                        }
                     }
                 }
             } else {
@@ -763,7 +789,7 @@ where
                 share_chain_sync_tx,
                 Duration::from_secs(30),
             )
-            .await;
+                .await;
         });
 
         self.main_loop().await

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -1,21 +1,20 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::fmt::Display;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
     path::PathBuf,
     sync::Arc,
     time::Duration,
 };
+use std::fmt::Display;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use convert_case::{Case, Casing};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::TokioAsyncResolver;
 use itertools::Itertools;
-use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
     futures::StreamExt,
     gossipsub,
@@ -23,17 +22,18 @@ use libp2p::{
     identify,
     identity::Keypair,
     kad,
-    kad::{store::MemoryStore, Event, Mode},
+    kad::{Event, Mode, store::MemoryStore},
     mdns,
     mdns::tokio::Tokio,
-    multiaddr::Protocol,
-    noise, request_response,
+    Multiaddr,
+    multiaddr::Protocol, noise,
+    request_response,
     request_response::{cbor, ResponseChannel},
-    swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, StreamProtocol, Swarm,
+    StreamProtocol, swarm::{NetworkBehaviour, SwarmEvent}, Swarm, tcp, yamux,
 };
-use log::kv::{ToValue, Value};
+use libp2p::swarm::behaviour::toggle::Toggle;
 use log::{debug, error, info, warn};
+use log::kv::{ToValue, Value};
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_utilities::hex::Hex;
@@ -45,19 +45,19 @@ use tokio::{
     sync::{broadcast, broadcast::error::RecvError},
 };
 
-use crate::server::p2p::messages::LocalShareChainSyncRequest;
 use crate::{
     server::{
         config,
         p2p::{
+            Error,
+            LibP2PError,
             messages,
-            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse},
-            peer_store::PeerStore,
-            Error, LibP2PError, ServiceClient,
+            messages::{PeerInfo, ShareChainSyncRequest, ShareChainSyncResponse}, peer_store::PeerStore, ServiceClient,
         },
     },
     sharechain::{block::Block, ShareChain},
 };
+use crate::server::p2p::messages::LocalShareChainSyncRequest;
 
 const PEER_INFO_TOPIC: &str = "peer_info";
 const NEW_BLOCK_TOPIC: &str = "new_block";
@@ -346,20 +346,20 @@ where
                             )
                             .map_err(|error| Error::LibP2P(LibP2PError::Publish(error)))
                         {
-                            Ok(_) => {},
+                            Ok(_) => {}
                             Err(error) => {
                                 error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to broadcast new block: {error:?}")
-                            },
+                            }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to convert block to bytes: {error:?}")
-                    },
+                    }
                 }
-            },
+            }
             Err(error) => {
                 error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to receive new block: {error:?}")
-            },
+            }
         }
     }
 
@@ -414,10 +414,10 @@ where
                 Ok(payload) => {
                     debug!(target: LOG_TARGET, tribe = &self.config.tribe; "[NETWORK] New peer info: {peer:?} -> {payload:?}");
                     self.network_peer_store.add(peer, payload).await;
-                },
+                }
                 Err(error) => {
                     error!(target: LOG_TARGET, tribe = &self.config.tribe; "Can't deserialize peer info payload: {:?}", error);
-                },
+                }
             },
             topic if topic == Self::tribe_topic(&self.config.tribe, PEER_INFO_TOPIC) => {
                 match messages::PeerInfo::try_from(message) {
@@ -431,12 +431,12 @@ where
                                 }
                             }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, tribe = &self.config.tribe; "Can't deserialize peer info payload: {:?}", error);
-                    },
+                    }
                 }
-            },
+            }
             // TODO: send a signature that proves that the actual block was coming from this peer
             // TODO: (sender peer's wallet address should be included always in the conibases with a fixed percent (like 20%))
             topic if topic == Self::tribe_topic(&self.config.tribe, NEW_BLOCK_TOPIC) => {
@@ -452,20 +452,20 @@ where
                                 if result.need_sync {
                                     self.sync_share_chain().await;
                                 }
-                            },
+                            }
                             Err(error) => {
                                 error!(target: LOG_TARGET, tribe = &self.config.tribe; "Could not add new block to local share chain: {error:?}");
-                            },
+                            }
                         }
-                    },
+                    }
                     Err(error) => {
                         error!(target: LOG_TARGET, tribe = &self.config.tribe; "Can't deserialize broadcast block payload: {:?}", error);
-                    },
+                    }
                 }
-            },
+            }
             _ => {
                 warn!(target: LOG_TARGET, tribe = &self.config.tribe; "Unknown topic {topic:?}!");
-            },
+            }
         }
     }
 
@@ -487,10 +487,10 @@ where
                 {
                     error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to send block sync response");
                 }
-            },
+            }
             Err(error) => {
                 error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to get blocks from height: {error:?}")
-            },
+            }
         }
     }
 
@@ -506,10 +506,10 @@ where
                 if result.need_sync {
                     self.sync_share_chain().await;
                 }
-            },
+            }
             Err(error) => {
                 error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to add synced blocks to share chain: {error:?}");
-            },
+            }
         }
     }
 
@@ -531,11 +531,11 @@ where
                     .behaviour_mut()
                     .share_chain_sync
                     .send_request(&result.peer_id, ShareChainSyncRequest::new(0));
-            },
+            }
             None => {
                 self.sync_in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to get peer with highest share chain height!")
-            },
+            }
         }
     }
 
@@ -580,17 +580,17 @@ where
                         } else {
                             in_progress.store(false, Ordering::SeqCst);
                         }
-                    },
+                    }
                     Err(error) => {
                         in_progress.store(false, Ordering::SeqCst);
                         error!(target: LOG_TARGET, tribe = &tribe; "Failed to get latest height of share chain: {error:?}")
-                    },
+                    }
                 }
-            },
+            }
             None => {
                 in_progress.store(false, Ordering::SeqCst);
                 error!(target: LOG_TARGET, tribe = &tribe; "Failed to get peer with highest share chain height!")
-            },
+            }
         }
     }
 
@@ -599,7 +599,7 @@ where
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(target: LOG_TARGET, tribe = &self.config.tribe; "Listening on {address:?}");
-            },
+            }
             SwarmEvent::Behaviour(event) => match event {
                 ServerNetworkBehaviourEvent::Mdns(mdns_event) => match mdns_event {
                     mdns::Event::Discovered(peers) => {
@@ -607,12 +607,12 @@ where
                             self.swarm.add_peer_address(peer, addr);
                             self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer);
                         }
-                    },
+                    }
                     mdns::Event::Expired(peers) => {
                         for (peer, _addr) in peers {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&peer);
                         }
-                    },
+                    }
                 },
                 ServerNetworkBehaviourEvent::Gossipsub(event) => match event {
                     gossipsub::Event::Message {
@@ -621,10 +621,10 @@ where
                         propagation_source: _propagation_source,
                     } => {
                         self.handle_new_gossipsub_message(message).await;
-                    },
-                    gossipsub::Event::Subscribed { .. } => {},
-                    gossipsub::Event::Unsubscribed { .. } => {},
-                    gossipsub::Event::GossipsubNotSupported { .. } => {},
+                    }
+                    gossipsub::Event::Subscribed { .. } => {}
+                    gossipsub::Event::Unsubscribed { .. } => {}
+                    gossipsub::Event::GossipsubNotSupported { .. } => {}
                 },
                 ServerNetworkBehaviourEvent::ShareChainSync(event) => match event {
                     request_response::Event::Message { peer: _peer, message } => match message {
@@ -634,27 +634,27 @@ where
                             channel,
                         } => {
                             self.handle_share_chain_sync_request(channel, request).await;
-                        },
+                        }
                         request_response::Message::Response {
                             request_id: _request_id,
                             response,
                         } => {
                             self.handle_share_chain_sync_response(response).await;
-                        },
+                        }
                     },
                     request_response::Event::OutboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, tribe = &self.config.tribe; "REQ-RES outbound failure: {peer:?} -> {error:?}");
-                    },
+                    }
                     request_response::Event::InboundFailure { peer, error, .. } => {
                         if self.sync_in_progress.load(Ordering::SeqCst) {
                             self.sync_in_progress.store(false, Ordering::SeqCst);
                         }
                         error!(target: LOG_TARGET, tribe = &self.config.tribe; "REQ-RES inbound failure: {peer:?} -> {error:?}");
-                    },
-                    request_response::Event::ResponseSent { .. } => {},
+                    }
+                    request_response::Event::ResponseSent { .. } => {}
                 },
                 ServerNetworkBehaviourEvent::Kademlia(event) => match event {
                     Event::RoutingUpdated {
@@ -670,7 +670,7 @@ where
                         if let Some(old_peer) = old_peer {
                             self.swarm.behaviour_mut().gossipsub.remove_explicit_peer(&old_peer);
                         }
-                    },
+                    }
                     _ => debug!(target: LOG_TARGET, tribe = &self.config.tribe; "[KADEMLIA] {event:?}"),
                 },
                 ServerNetworkBehaviourEvent::Identify(event) => {
@@ -680,9 +680,9 @@ where
                         }
                         self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
                     }
-                },
+                }
             },
-            _ => {},
+            _ => {}
         };
     }
 
@@ -784,17 +784,17 @@ where
                                             if let Some(peer_id) = peer_id {
                                                 self.swarm.behaviour_mut().kademlia.add_address(&peer_id, parsed_addr);
                                             }
-                                        },
+                                        }
                                         Err(error) => {
                                             warn!(target: LOG_TARGET, tribe = &self.config.tribe; "Skipping invalid DNS entry: {:?}: {error:?}", chars);
-                                        },
+                                        }
                                     }
                                 }
                             }
-                        },
+                        }
                         Err(error) => {
                             error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to lookup domain records: {error:?}");
-                        },
+                        }
                     }
                 }
             } else {
@@ -858,9 +858,13 @@ where
                 Duration::from_secs(30),
                 tribe,
             )
-            .await;
+                .await;
         });
 
         self.main_loop().await
+    }
+
+    pub fn network_peer_store(&self) -> Arc<PeerStore> {
+        self.network_peer_store.clone()
     }
 }

--- a/src/server/p2p/peer_store.rs
+++ b/src/server/p2p/peer_store.rs
@@ -5,13 +5,16 @@ use std::{
     sync::RwLock,
     time::{Duration, Instant},
 };
+use std::collections::HashSet;
 
+use itertools::Itertools;
 use libp2p::PeerId;
 use log::{debug, warn};
 use moka::future::{Cache, CacheBuilder};
 use tari_utilities::epoch_time::EpochTime;
 
 use crate::server::p2p::messages::PeerInfo;
+use crate::server::p2p::Tribe;
 
 const LOG_TARGET: &str = "p2pool::server::p2p::peer_store";
 
@@ -29,7 +32,7 @@ impl Default for PeerStoreConfig {
 }
 
 /// A record in peer store that holds all needed info of a peer.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct PeerStoreRecord {
     peer_info: PeerInfo,
     created: Instant,
@@ -60,12 +63,12 @@ impl PeerStoreBlockHeightTip {
 /// A peer store, which stores all the known peers (from broadcasted [`PeerInfo`] messages) in-memory.
 /// This implementation is thread safe and async, so an [`Arc<PeerStore>`] is enough to be used to share.
 pub struct PeerStore {
-    inner: Cache<PeerId, PeerStoreRecord>,
-    // Max time to live for the items to avoid non-existing peers in list.
+    peers: Cache<PeerId, PeerStoreRecord>,
+    /// Max time to live for the items to avoid non-existing peers in list.
     ttl: Duration,
-    // Peer with the highest share chain height.
+    /// Peer with the highest share chain height.
     tip_of_block_height: RwLock<Option<PeerStoreBlockHeightTip>>,
-    // The last time when we had more than 0 peers.
+    /// The last time when we had more than 0 peers.
     last_connected: RwLock<Option<EpochTime>>,
 }
 
@@ -73,7 +76,7 @@ impl PeerStore {
     /// Constructs a new peer store with config.
     pub fn new(config: &PeerStoreConfig) -> Self {
         Self {
-            inner: CacheBuilder::new(100_000).time_to_live(config.peer_record_ttl).build(),
+            peers: CacheBuilder::new(100_000).time_to_live(config.peer_record_ttl).build(),
             ttl: config.peer_record_ttl,
             tip_of_block_height: RwLock::new(None),
             last_connected: RwLock::new(None),
@@ -83,22 +86,30 @@ impl PeerStore {
     /// Add a new peer to store.
     /// If a peer already exists, just replaces it.
     pub async fn add(&self, peer_id: PeerId, peer_info: PeerInfo) {
-        self.inner.insert(peer_id, PeerStoreRecord::new(peer_info)).await;
+        self.peers.insert(peer_id, PeerStoreRecord::new(peer_info)).await;
         self.set_tip_of_block_height().await;
         self.set_last_connected().await;
+    }
+
+    /// Collects all current tribes from all PeerInfo collected from broadcasts.
+    pub async fn tribes(&self) -> Vec<Tribe> {
+        self.peers.iter()
+            .map(|(_, record)| { record.peer_info.tribe })
+            .unique()
+            .collect_vec()
     }
 
     /// Returns count of peers.
     /// Note: it is needed to calculate number of validations needed to make sure a new block is valid.
     pub async fn peer_count(&self) -> u64 {
         self.set_last_connected().await;
-        self.inner.entry_count()
+        self.peers.entry_count()
     }
 
     /// Sets the actual highest block height with peer.
     async fn set_tip_of_block_height(&self) {
         if let Some((k, v)) = self
-            .inner
+            .peers
             .iter()
             .max_by(|(_k1, v1), (_k2, v2)| v1.peer_info.current_height.cmp(&v2.peer_info.current_height))
         {
@@ -131,14 +142,14 @@ impl PeerStore {
     pub async fn cleanup(&self) -> Vec<PeerId> {
         let mut expired_peers = vec![];
 
-        for (k, v) in &self.inner {
+        for (k, v) in &self.peers {
             debug!(target: LOG_TARGET, "{:?} -> {:?}", k, v);
             let elapsed = v.created.elapsed();
             let expired = elapsed.gt(&self.ttl);
             debug!(target: LOG_TARGET, "{:?} ttl elapsed: {:?} <-> {:?}, Expired: {:?}", k, elapsed, &self.ttl, expired);
             if expired {
                 expired_peers.push(*k);
-                self.inner.remove(k.as_ref()).await;
+                self.peers.remove(k.as_ref()).await;
             }
         }
 
@@ -150,7 +161,7 @@ impl PeerStore {
 
     pub async fn set_last_connected(&self) {
         if let Ok(mut last_connected) = self.last_connected.write() {
-            if self.inner.entry_count() > 0 {
+            if self.peers.entry_count() > 0 {
                 if last_connected.is_none() {
                     let _ = last_connected.insert(EpochTime::now());
                 }

--- a/src/server/p2p/peer_store.rs
+++ b/src/server/p2p/peer_store.rs
@@ -5,7 +5,6 @@ use std::{
     sync::RwLock,
     time::{Duration, Instant},
 };
-use std::collections::HashSet;
 
 use itertools::Itertools;
 use libp2p::PeerId;
@@ -93,8 +92,9 @@ impl PeerStore {
 
     /// Collects all current tribes from all PeerInfo collected from broadcasts.
     pub async fn tribes(&self) -> Vec<Tribe> {
-        self.peers.iter()
-            .map(|(_, record)| { record.peer_info.tribe })
+        self.peers
+            .iter()
+            .map(|(_, record)| record.peer_info.tribe)
             .unique()
             .collect_vec()
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,21 +1,18 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::atomic::AtomicBool;
 use std::{
     net::{AddrParseError, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
+use std::sync::atomic::AtomicBool;
 
 use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 
-use crate::server::http::stats::server::StatsServer;
-use crate::server::p2p::peer_store::PeerStore;
-use crate::server::stats_store::StatsStore;
 use crate::{
     server::{
         config, grpc,
@@ -24,6 +21,9 @@ use crate::{
     },
     sharechain::ShareChain,
 };
+use crate::server::http::stats::server::StatsServer;
+use crate::server::p2p::peer_store::PeerStore;
+use crate::server::stats_store::StatsStore;
 
 const LOG_TARGET: &str = "p2pool::server::server";
 
@@ -50,7 +50,6 @@ where
     shutdown_signal: ShutdownSignal,
 }
 
-// TODO: handle and use shutdown_signal
 impl<S> Server<S>
 where
     S: ShareChain,
@@ -70,8 +69,8 @@ where
             sync_in_progress.clone(),
             shutdown_signal.clone(),
         )
-        .await
-        .map_err(Error::P2PService)?;
+            .await
+            .map_err(Error::P2PService)?;
 
         let mut base_node_grpc_server = None;
         let mut p2pool_server = None;
@@ -87,8 +86,8 @@ where
                 share_chain.clone(),
                 stats_store.clone(),
             )
-            .await
-            .map_err(Error::Grpc)?;
+                .await
+                .map_err(Error::Grpc)?;
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,18 +1,21 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::sync::atomic::AtomicBool;
 use std::{
     net::{AddrParseError, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
-use std::sync::atomic::AtomicBool;
 
 use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 
+use crate::server::http::stats::server::StatsServer;
+use crate::server::p2p::peer_store::PeerStore;
+use crate::server::stats_store::StatsStore;
 use crate::{
     server::{
         config, grpc,
@@ -21,9 +24,6 @@ use crate::{
     },
     sharechain::ShareChain,
 };
-use crate::server::http::stats::server::StatsServer;
-use crate::server::p2p::peer_store::PeerStore;
-use crate::server::stats_store::StatsStore;
 
 const LOG_TARGET: &str = "p2pool::server::server";
 
@@ -68,9 +68,10 @@ where
             tribe_peer_store.clone(),
             network_peer_store.clone(),
             sync_in_progress.clone(),
+            shutdown_signal.clone(),
         )
-            .await
-            .map_err(Error::P2PService)?;
+        .await
+        .map_err(Error::P2PService)?;
 
         let mut base_node_grpc_server = None;
         let mut p2pool_server = None;
@@ -86,8 +87,8 @@ where
                 share_chain.clone(),
                 stats_store.clone(),
             )
-                .await
-                .map_err(Error::Grpc)?;
+            .await
+            .map_err(Error::Grpc)?;
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 
@@ -97,6 +98,7 @@ where
                 tribe_peer_store.clone(),
                 stats_store.clone(),
                 config.stats_server.port,
+                shutdown_signal.clone(),
             )))
         } else {
             None
@@ -116,13 +118,17 @@ where
         base_node_service: BaseNodeServer<TariBaseNodeGrpc>,
         p2pool_service: ShaP2PoolServer<ShaP2PoolGrpc<S>>,
         grpc_port: u16,
+        shutdown_signal: ShutdownSignal,
     ) -> Result<(), Error> {
         info!(target: LOG_TARGET, "Starting gRPC server on port {}!", &grpc_port);
 
         tonic::transport::Server::builder()
             .add_service(base_node_service)
             .add_service(p2pool_service)
-            .serve(SocketAddr::from_str(format!("0.0.0.0:{}", grpc_port).as_str()).map_err(Error::AddrParse)?)
+            .serve_with_shutdown(
+                SocketAddr::from_str(format!("0.0.0.0:{}", grpc_port).as_str()).map_err(Error::AddrParse)?,
+                shutdown_signal,
+            )
             .await
             .map_err(|err| {
                 error!(target: LOG_TARGET, "GRPC encountered an error: {:?}", err);
@@ -142,12 +148,12 @@ where
             let base_node_grpc_service = self.base_node_grpc_service.clone().unwrap();
             let p2pool_grpc_service = self.p2pool_grpc_service.clone().unwrap();
             let grpc_port = self.config.grpc_port;
+            let shutdown_signal = self.shutdown_signal.clone();
             tokio::spawn(async move {
-                match Self::start_grpc(base_node_grpc_service, p2pool_grpc_service, grpc_port).await {
-                    Ok(_) => {}
-                    Err(error) => {
-                        error!(target: LOG_TARGET, "GRPC Server encountered an error: {:?}", error);
-                    }
+                if let Err(error) =
+                    Self::start_grpc(base_node_grpc_service, p2pool_grpc_service, grpc_port, shutdown_signal).await
+                {
+                    error!(target: LOG_TARGET, "GRPC Server encountered an error: {:?}", error);
                 }
             });
         }
@@ -155,16 +161,17 @@ where
         if let Some(stats_server) = &self.stats_server {
             let stats_server = stats_server.clone();
             tokio::spawn(async move {
-                match stats_server.start().await {
-                    Ok(_) => {}
-                    Err(error) => {
-                        error!(target: LOG_TARGET, "Stats HTTP server encountered an error: {:?}", error);
-                    }
+                if let Err(error) = stats_server.start().await {
+                    error!(target: LOG_TARGET, "Stats HTTP server encountered an error: {:?}", error);
                 }
             });
         }
 
-        self.p2p_service.start().await.map_err(Error::P2PService)
+        self.p2p_service.start().await.map_err(Error::P2PService)?;
+
+        info!(target: LOG_TARGET, "Server stopped!");
+
+        Ok(())
     }
 
     pub fn p2p_service(&self) -> &p2p::Service<S> {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,18 +1,21 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::sync::atomic::AtomicBool;
 use std::{
     net::{AddrParseError, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
-use std::sync::atomic::AtomicBool;
 
 use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 
+use crate::server::http::stats::server::StatsServer;
+use crate::server::p2p::peer_store::PeerStore;
+use crate::server::stats_store::StatsStore;
 use crate::{
     server::{
         config, grpc,
@@ -21,9 +24,6 @@ use crate::{
     },
     sharechain::ShareChain,
 };
-use crate::server::http::stats::server::StatsServer;
-use crate::server::p2p::peer_store::PeerStore;
-use crate::server::stats_store::StatsStore;
 
 const LOG_TARGET: &str = "p2pool::server::server";
 
@@ -69,8 +69,8 @@ where
             sync_in_progress.clone(),
             shutdown_signal.clone(),
         )
-            .await
-            .map_err(Error::P2PService)?;
+        .await
+        .map_err(Error::P2PService)?;
 
         let mut base_node_grpc_server = None;
         let mut p2pool_server = None;
@@ -86,8 +86,8 @@ where
                 share_chain.clone(),
                 stats_store.clone(),
             )
-                .await
-                .map_err(Error::Grpc)?;
+            .await
+            .map_err(Error::Grpc)?;
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,18 +1,20 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::sync::atomic::AtomicBool;
 use std::{
     net::{AddrParseError, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
-use std::sync::atomic::AtomicBool;
 
 use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use thiserror::Error;
-use tokio::sync::{broadcast, RwLock};
 
+use crate::server::http::stats::server::StatsServer;
+use crate::server::p2p::peer_store::PeerStore;
+use crate::server::stats_store::StatsStore;
 use crate::{
     server::{
         config, grpc,
@@ -21,11 +23,6 @@ use crate::{
     },
     sharechain::ShareChain,
 };
-use crate::server::http::stats::server::StatsServer;
-use crate::server::p2p::peer_store::PeerStore;
-use crate::server::p2p::Tribe;
-use crate::server::stats_store::StatsStore;
-use crate::sharechain::block::Block;
 
 const LOG_TARGET: &str = "p2pool::server::server";
 
@@ -70,8 +67,8 @@ where
             network_peer_store.clone(),
             sync_in_progress.clone(),
         )
-            .await
-            .map_err(Error::P2PService)?;
+        .await
+        .map_err(Error::P2PService)?;
 
         let mut base_node_grpc_server = None;
         let mut p2pool_server = None;
@@ -87,8 +84,8 @@ where
                 share_chain.clone(),
                 stats_store.clone(),
             )
-                .await
-                .map_err(Error::Grpc)?;
+            .await
+            .map_err(Error::Grpc)?;
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 
@@ -144,10 +141,10 @@ where
             let grpc_port = self.config.grpc_port;
             tokio::spawn(async move {
                 match Self::start_grpc(base_node_grpc_service, p2pool_grpc_service, grpc_port).await {
-                    Ok(_) => {}
+                    Ok(_) => {},
                     Err(error) => {
                         error!(target: LOG_TARGET, "GRPC Server encountered an error: {:?}", error);
-                    }
+                    },
                 }
             });
         }
@@ -156,10 +153,10 @@ where
             let stats_server = stats_server.clone();
             tokio::spawn(async move {
                 match stats_server.start().await {
-                    Ok(_) => {}
+                    Ok(_) => {},
                     Err(error) => {
                         error!(target: LOG_TARGET, "Stats HTTP server encountered an error: {:?}", error);
-                    }
+                    },
                 }
             });
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -59,13 +59,15 @@ where
     pub async fn new(config: config::Config, share_chain: S) -> Result<Self, Error> {
         let share_chain = Arc::new(share_chain);
         let sync_in_progress = Arc::new(AtomicBool::new(true));
-        let peer_store = Arc::new(PeerStore::new(&config.peer_store));
+        let tribe_peer_store = Arc::new(PeerStore::new(&config.peer_store));
+        let network_peer_store = Arc::new(PeerStore::new(&config.peer_store));
         let stats_store = Arc::new(StatsStore::new());
 
         let mut p2p_service: p2p::Service<S> = p2p::Service::new(
             &config,
             share_chain.clone(),
-            peer_store.clone(),
+            tribe_peer_store.clone(),
+            network_peer_store.clone(),
             sync_in_progress.clone(),
         )
             .await
@@ -93,7 +95,7 @@ where
         let stats_server = if config.stats_server.enabled {
             Some(Arc::new(StatsServer::new(
                 share_chain.clone(),
-                peer_store.clone(),
+                tribe_peer_store.clone(),
                 stats_store.clone(),
                 config.stats_server.port,
             )))

--- a/src/sharechain/tests/test.rs
+++ b/src/sharechain/tests/test.rs
@@ -8,12 +8,10 @@ mod tests {
     use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
     use tari_crypto::{keys::PublicKey as CryptoPubKey, ristretto::RistrettoPublicKey};
 
-    use crate::{
-        sharechain::{
-            block::{Block as ShareChainBlock, BlockBuilder},
-            ShareChain,
-        },
-        InMemoryShareChain,
+    use crate::sharechain::in_memory::InMemoryShareChain;
+    use crate::sharechain::{
+        block::{Block as ShareChainBlock, BlockBuilder},
+        ShareChain,
     };
 
     fn new_random_address() -> TariAddress {


### PR DESCRIPTION
Description
---
We needed tribes to let people mine together in a smaller group called tribe. P2pool must allow this functionality.
Also we should have the chance to list all current tribes, cli of p2pool should support this.
As a plus p2pool should support graceful shutdown.

Motivation and Context
---

How Has This Been Tested?
---

**Testing tribes**

1. Start p2pool node on tribe `a`: `export TARI_NETWORK="esmeralda" && ./target/release/sha_p2pool start -g 18145 --tribe a`
2. Start mining on this p2pool node
3. Start another p2pool node on tribe `b`: `export TARI_NETWORK="esmeralda" && ./target/release/sha_p2pool start -g 18146 --tribe b`
4. Start mining on this other p2pool node
5. It should be visible from the logs that the 2 pools have a different share chain

**Testing list tribes**
Simply run `sha_p2pool list-tribes`
Example output:
```json
["default","a"]
```

What process can a PR reviewer use to test or verify this change?
---
See tests


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Peer info contains tribe now

BREAKING CHANGE: Seed peers needs to be updated to the latest version as Peer info contains tribe now
