### PR TITLE
fix: remove unneeded termination handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,16 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
-dependencies = [
- "nix 0.29.0",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,18 +3101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,7 +3945,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.24.3",
+ "nix",
  "thiserror",
  "tokio",
 ]
@@ -4308,7 +4286,6 @@ dependencies = [
  "blake2",
  "clap 4.5.9",
  "convert_case",
- "ctrlc",
  "digest",
  "dirs",
  "hex",
@@ -5876,15 +5853,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix 0.29.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,6 +3111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,7 +3967,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix",
+ "nix 0.24.3",
  "thiserror",
  "tokio",
 ]
@@ -4286,6 +4308,7 @@ dependencies = [
  "blake2",
  "clap 4.5.9",
  "convert_case",
+ "ctrlc",
  "digest",
  "dirs",
  "hex",
@@ -4302,7 +4325,6 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "signal-hook",
  "tari_common",
  "tari_common_types",
  "tari_core",
@@ -4312,16 +4334,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]
@@ -5864,6 +5876,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ hex = "0.4.3"
 serde_json = "1.0.122"
 hickory-resolver = { version = "*", features = ["dns-over-rustls"] }
 convert_case = "0.6.0"
-ctrlc = { version = "3.4.5", features = ["termination"] }
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hex = "0.4.3"
 serde_json = "1.0.122"
 hickory-resolver = { version = "*", features = ["dns-over-rustls"] }
 convert_case = "0.6.0"
-signal-hook = "0.3.17"
+ctrlc = { version = "3.4.5", features = ["termination"] }
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,6 @@ mod sharechain;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let mut cli_shutdown = Shutdown::new();
-    let cli_shutdown_signal = cli_shutdown.to_signal();
-    ctrlc::set_handler(move || cli_shutdown.trigger()).expect("Error setting termination handler");
-    Cli::parse().handle_command(cli_shutdown_signal).await?;
+    Cli::parse().handle_command(Shutdown::new().to_signal()).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use clap::Parser;
-use signal_hook::consts::{SIGINT, SIGQUIT, SIGTERM};
-use signal_hook::iterator::Signals;
 use tari_shutdown::Shutdown;
 
 use crate::cli::Cli;
@@ -14,18 +12,9 @@ mod sharechain;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // shutdown hook
     let mut cli_shutdown = Shutdown::new();
     let cli_shutdown_signal = cli_shutdown.to_signal();
-    let mut signals = Signals::new([SIGINT, SIGTERM, SIGQUIT])?;
-    let signals_handle = signals.handle();
-    tokio::spawn(async move {
-        let _ = signals.forever().next();
-        cli_shutdown.trigger();
-    });
-
-    // cli
+    ctrlc::set_handler(move || cli_shutdown.trigger()).expect("Error setting termination handler");
     Cli::parse().handle_command(cli_shutdown_signal).await?;
-    signals_handle.close();
     Ok(())
 }

--- a/src/server/grpc/base_node.rs
+++ b/src/server/grpc/base_node.rs
@@ -21,6 +21,7 @@ use minotari_app_grpc::{
         ValueAtHeightResponse,
     },
 };
+use tari_shutdown::ShutdownSignal;
 use tokio::sync::Mutex;
 use tonic::{transport::Channel, Request, Response, Status, Streaming};
 
@@ -100,9 +101,11 @@ pub struct TariBaseNodeGrpc {
 }
 
 impl TariBaseNodeGrpc {
-    pub async fn new(base_node_address: String) -> Result<Self, Error> {
+    pub async fn new(base_node_address: String, shutdown_signal: ShutdownSignal) -> Result<Self, Error> {
         Ok(Self {
-            client: Arc::new(Mutex::new(util::connect_base_node(base_node_address).await?)),
+            client: Arc::new(Mutex::new(
+                util::connect_base_node(base_node_address, shutdown_signal).await?,
+            )),
         })
     }
 }

--- a/src/server/grpc/error.rs
+++ b/src/server/grpc/error.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("Tonic error: {0}")]
     Tonic(#[from] TonicError),
+    #[error("Shutdown")]
+    Shutdown,
 }
 
 #[derive(Error, Debug)]

--- a/src/server/grpc/p2pool.rs
+++ b/src/server/grpc/p2pool.rs
@@ -10,6 +10,7 @@ use minotari_app_grpc::tari_rpc::{
     SubmitBlockRequest, SubmitBlockResponse,
 };
 use tari_core::proof_of_work::sha3x_difficulty;
+use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
@@ -53,9 +54,12 @@ where
         p2p_client: p2p::ServiceClient,
         share_chain: Arc<S>,
         stats_store: Arc<StatsStore>,
+        shutdown_signal: ShutdownSignal,
     ) -> Result<Self, Error> {
         Ok(Self {
-            client: Arc::new(Mutex::new(util::connect_base_node(base_node_address).await?)),
+            client: Arc::new(Mutex::new(
+                util::connect_base_node(base_node_address, shutdown_signal).await?,
+            )),
             p2p_client,
             share_chain,
             stats_store,

--- a/src/server/grpc/util.rs
+++ b/src/server/grpc/util.rs
@@ -6,13 +6,18 @@ use std::time::Duration;
 use log::error;
 use minotari_app_grpc::tari_rpc::base_node_client::BaseNodeClient;
 use minotari_node_grpc_client::BaseNodeGrpcClient;
+use tari_shutdown::ShutdownSignal;
+use tokio::select;
 use tokio::time::sleep;
 use tonic::transport::Channel;
 
 use crate::server::grpc::error::{Error, TonicError};
 
 /// Utility function to connect to a Base node and try infinitely when it fails until gets connected.
-pub async fn connect_base_node(base_node_address: String) -> Result<BaseNodeClient<Channel>, Error> {
+pub async fn connect_base_node(
+    base_node_address: String,
+    shutdown_signal: ShutdownSignal,
+) -> Result<BaseNodeClient<Channel>, Error> {
     let client_result = BaseNodeGrpcClient::connect(base_node_address.clone())
         .await
         .map_err(|e| Error::Tonic(TonicError::Transport(e)));
@@ -21,6 +26,7 @@ pub async fn connect_base_node(base_node_address: String) -> Result<BaseNodeClie
         Err(error) => {
             error!("[Retry] Failed to connect to Tari base node: {:?}", error.to_string());
             let mut client = None;
+            tokio::pin!(shutdown_signal);
             while client.is_none() {
                 sleep(Duration::from_secs(5)).await;
                 match BaseNodeGrpcClient::connect(base_node_address.clone())
@@ -29,6 +35,14 @@ pub async fn connect_base_node(base_node_address: String) -> Result<BaseNodeClie
                 {
                     Ok(curr_client) => client = Some(curr_client),
                     Err(error) => error!("[Retry] Failed to connect to Tari base node: {:?}", error.to_string()),
+                }
+                select! {
+                    () = &mut shutdown_signal => {
+                        return Err(Error::Shutdown);
+                    }
+                    else => {
+                        continue;
+                    }
                 }
             }
             client.unwrap()

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -75,9 +75,10 @@ where
         let mut base_node_grpc_server = None;
         let mut p2pool_server = None;
         if config.mining_enabled {
-            let base_node_grpc_service = TariBaseNodeGrpc::new(config.base_node_address.clone())
-                .await
-                .map_err(Error::Grpc)?;
+            let base_node_grpc_service =
+                TariBaseNodeGrpc::new(config.base_node_address.clone(), shutdown_signal.clone())
+                    .await
+                    .map_err(Error::Grpc)?;
             base_node_grpc_server = Some(BaseNodeServer::new(base_node_grpc_service));
 
             let p2pool_grpc_service = ShaP2PoolGrpc::new(
@@ -85,6 +86,7 @@ where
                 p2p_service.client(),
                 share_chain.clone(),
                 stats_store.clone(),
+                shutdown_signal.clone(),
             )
             .await
             .map_err(Error::Grpc)?;


### PR DESCRIPTION
Description
---
Windows build were failing because we were using a unix only compatible termination handling lib.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
