### PR TITLE
feat(cli): make base node address configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "sha_p2pool"
-version = "0.1.4-pre.0"
+version = "0.1.4-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha_p2pool"
-version = "0.1.4-pre.0"
+version = "0.1.4-pre.1"
 edition = "2021"
 
 [dependencies]

--- a/log4rs_sample.yml
+++ b/log4rs_sample.yml
@@ -31,6 +31,7 @@ root:
   level: info
   appenders:
     - stdout
+    - p2pool
 
 loggers:
   sharechain:

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -30,6 +30,10 @@ pub struct StartArgs {
     #[arg(long, value_name = "stats-server-port")]
     pub stats_server_port: Option<u16>,
 
+    /// (Optional) Address of the Tari base node.
+    #[arg(long, value_name = "base-node-address", default_value = "http://127.0.0.1:18142")]
+    pub base_node_address: String,
+
     /// (Optional) seed peers.
     /// Any amount of seed peers can be added to join a p2pool network.
     ///

--- a/src/cli/commands/util.rs
+++ b/src/cli/commands/util.rs
@@ -71,6 +71,7 @@ pub async fn server(
     if let Some(stats_server_port) = args.stats_server_port {
         config_builder.with_stats_server_port(stats_server_port);
     }
+    config_builder.with_base_node_address(args.base_node_address.clone());
 
     let config = config_builder.build();
     let share_chain = InMemoryShareChain::default();

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -120,6 +120,11 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn with_base_node_address(&mut self, config: String) -> &mut Self {
+        self.config.base_node_address = config;
+        self
+    }
+
     pub fn build(&self) -> Config {
         self.config.clone()
     }


### PR DESCRIPTION
Description
---
Base node (where p2pool connects to) was not able to configure (it's address) from CLI, so it must be.

Motivation and Context
---

How Has This Been Tested?
---
Starting p2pool with `--base-node-address="http://127.0.0.1:9999"` and see that it could not connect as it tries to use new address. When set back to `--base-node-address="http://127.0.0.1:18142"` it was working fine again.

What process can a PR reviewer use to test or verify this change?
---
See test.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
