### PR TITLE
fix: adjust share count and fix http stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,6 +4308,7 @@ dependencies = [
  "hex",
  "hickory-resolver",
  "itertools 0.13.0",
+ "lazy_static",
  "libp2p",
  "log",
  "log4rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "sha_p2pool"
-version = "0.1.5-pre.3"
+version = "0.1.5-pre.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ hex = "0.4.3"
 serde_json = "1.0.122"
 hickory-resolver = { version = "*", features = ["dns-over-rustls"] }
 convert_case = "0.6.0"
+lazy_static = "1.5.0"
 
 [package.metadata.cargo-machete]
 ignored = ["log4rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha_p2pool"
-version = "0.1.5-pre.3"
+version = "0.1.5-pre.4"
 edition = "2021"
 
 [dependencies]

--- a/src/server/grpc/error.rs
+++ b/src/server/grpc/error.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("Tonic error: {0}")]
     Tonic(#[from] TonicError),
+    #[error("No consensus constants found")]
+    NoConsensusConstants,
     #[error("Shutdown")]
     Shutdown,
 }

--- a/src/server/grpc/p2pool.rs
+++ b/src/server/grpc/p2pool.rs
@@ -1,16 +1,18 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
+use itertools::Itertools;
 use log::{error, info, warn};
 use minotari_app_grpc::tari_rpc::pow_algo::PowAlgos;
 use minotari_app_grpc::tari_rpc::{
     base_node_client::BaseNodeClient, sha_p2_pool_server::ShaP2Pool, GetNewBlockRequest, GetNewBlockResponse,
     GetNewBlockTemplateWithCoinbasesRequest, NewBlockTemplateRequest, SubmitBlockRequest, SubmitBlockResponse,
 };
+use num::ToPrimitive;
+use std::collections::HashMap;
+use std::sync::Arc;
 use tari_common::configuration::Network;
+use tari_common_types::tari_address::TariAddress;
 use tari_common_types::types::FixedHash;
 use tari_core::consensus;
 use tari_core::consensus::ConsensusManager;
@@ -26,7 +28,7 @@ use crate::server::http::stats::{
     P2POOL_STAT_ACCEPTED_BLOCKS_COUNT, P2POOL_STAT_REJECTED_BLOCKS_COUNT,
 };
 use crate::server::stats_store::StatsStore;
-use crate::sharechain::BlockValidationParams;
+use crate::sharechain::{BlockValidationParams, BLOCKS_WINDOW};
 use crate::{
     server::{
         grpc::{error::Error, util},
@@ -36,6 +38,8 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "p2pool::server::grpc::p2pool";
+
+const MAX_SUBMITTED_BLOCKS: u64 = BLOCKS_WINDOW as u64 / 2;
 
 pub fn min_difficulty(pow: PowAlgorithm) -> Result<u64, Error> {
     let network = Network::get_current_or_user_setting_or_default();
@@ -106,6 +110,43 @@ where
         })
     }
 
+    async fn submitted_shares_count(&self, pow: PowAlgorithm, miner_wallet_address: TariAddress) -> u64 {
+        let share_chain = match pow {
+            PowAlgorithm::RandomX => self.share_chain_random_x.clone(),
+            PowAlgorithm::Sha3x => self.share_chain_sha3x.clone(),
+        };
+        match share_chain.blocks(0).await {
+            Ok(blocks) => blocks
+                .iter()
+                .tail(BLOCKS_WINDOW)
+                .filter(|block| {
+                    if let Some(addr) = block.miner_wallet_address() {
+                        return miner_wallet_address == *addr;
+                    }
+                    false
+                })
+                .count()
+                .to_u64()
+                .unwrap(),
+            Err(error) => {
+                warn!(target: LOG_TARGET, "[{}] Failed to get share chain blocks: {error:?}", pow);
+                0
+            },
+        }
+    }
+
+    async fn can_submit_block(&self, pow: PowAlgorithm, block: &Block) -> bool {
+        match block.miner_wallet_address() {
+            Some(miner_wallet_address) => {
+                self.submitted_shares_count(pow, miner_wallet_address.clone()).await < MAX_SUBMITTED_BLOCKS
+            },
+            None => {
+                warn!(target: LOG_TARGET, "Missing miner wallet address!");
+                false
+            },
+        }
+    }
+
     /// Submits a new block to share chain and broadcasts to the p2p network.
     pub async fn submit_share_chain_block(&self, block: &Block) -> Result<(), Status> {
         let pow_algo = block.original_block_header().pow.pow_algo;
@@ -113,6 +154,10 @@ where
             PowAlgorithm::RandomX => self.share_chain_random_x.clone(),
             PowAlgorithm::Sha3x => self.share_chain_sha3x.clone(),
         };
+        if !self.can_submit_block(pow_algo, block).await {
+            warn!(target: LOG_TARGET, "Skipping block submission.. Too many blocks sent!");
+            return Ok(());
+        }
         match share_chain.submit_block(block).await {
             Ok(_) => {
                 self.stats_store

--- a/src/server/http/server.rs
+++ b/src/server/http/server.rs
@@ -3,7 +3,6 @@
 
 use crate::server::http::stats::cache::StatsCache;
 use crate::server::http::stats::handlers;
-use crate::server::http::stats::models::{BlockStats, EstimatedEarnings, Stats, TribeDetails};
 use crate::server::http::{health, version};
 use crate::server::p2p::peer_store::PeerStore;
 use crate::server::p2p::Tribe;
@@ -13,12 +12,9 @@ use axum::routing::get;
 use axum::Router;
 use log::info;
 use std::sync::Arc;
-use std::time::Duration;
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 use tokio::io;
-use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
-use tokio::time::Instant;
 
 const LOG_TARGET: &str = "p2pool::server::stats";
 

--- a/src/server/http/server.rs
+++ b/src/server/http/server.rs
@@ -1,21 +1,24 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::Arc;
-
-use axum::routing::get;
-use axum::Router;
-use log::info;
-use tari_shutdown::ShutdownSignal;
-use thiserror::Error;
-use tokio::io;
-
+use crate::server::http::stats::cache::StatsCache;
 use crate::server::http::stats::handlers;
+use crate::server::http::stats::models::{BlockStats, EstimatedEarnings, Stats, TribeDetails};
 use crate::server::http::{health, version};
 use crate::server::p2p::peer_store::PeerStore;
 use crate::server::p2p::Tribe;
 use crate::server::stats_store::StatsStore;
 use crate::sharechain::ShareChain;
+use axum::routing::get;
+use axum::Router;
+use log::info;
+use std::sync::Arc;
+use std::time::Duration;
+use tari_shutdown::ShutdownSignal;
+use thiserror::Error;
+use tokio::io;
+use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
+use tokio::time::Instant;
 
 const LOG_TARGET: &str = "p2pool::server::stats";
 
@@ -50,6 +53,7 @@ where
     stats_store: Arc<StatsStore>,
     port: u16,
     tribe: Tribe,
+    stats_cache: Arc<StatsCache>,
     shutdown_signal: ShutdownSignal,
 }
 
@@ -60,6 +64,7 @@ pub struct AppState {
     pub peer_store: Arc<PeerStore>,
     pub stats_store: Arc<StatsStore>,
     pub tribe: Tribe,
+    pub stats_cache: Arc<StatsCache>,
 }
 
 impl<S> HttpServer<S>
@@ -73,6 +78,7 @@ where
         stats_store: Arc<StatsStore>,
         port: u16,
         tribe: Tribe,
+        stats_cache: Arc<StatsCache>,
         shutdown_signal: ShutdownSignal,
     ) -> Self {
         Self {
@@ -82,6 +88,7 @@ where
             stats_store,
             port,
             tribe,
+            stats_cache,
             shutdown_signal,
         }
     }
@@ -98,6 +105,7 @@ where
                 peer_store: self.peer_store.clone(),
                 stats_store: self.stats_store.clone(),
                 tribe: self.tribe.clone(),
+                stats_cache: self.stats_cache.clone(),
             })
     }
 

--- a/src/server/http/stats/cache.rs
+++ b/src/server/http/stats/cache.rs
@@ -12,10 +12,7 @@ pub struct CachedStats {
 
 impl CachedStats {
     pub fn new(stats: Stats, last_update: Instant) -> Self {
-        Self {
-            stats,
-            last_update,
-        }
+        Self { stats, last_update }
     }
 
     pub fn stats(&self) -> &Stats {
@@ -26,7 +23,6 @@ impl CachedStats {
         self.last_update
     }
 }
-
 
 pub struct StatsCache {
     ttl: Duration,
@@ -47,10 +43,10 @@ impl StatsCache {
             Some(curr_stats) => {
                 curr_stats.stats = stats;
                 curr_stats.last_update = Instant::now();
-            }
+            },
             None => {
                 *stats_lock = Some(CachedStats::new(stats, Instant::now()));
-            }
+            },
         }
     }
 
@@ -64,4 +60,3 @@ impl StatsCache {
         (*lock).as_ref().map(|cached_stats| cached_stats.stats.clone())
     }
 }
-

--- a/src/server/http/stats/cache.rs
+++ b/src/server/http/stats/cache.rs
@@ -1,0 +1,67 @@
+use crate::server::http::stats::models::Stats;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+
+#[derive(Clone)]
+pub struct CachedStats {
+    stats: Stats,
+    last_update: Instant,
+}
+
+impl CachedStats {
+    pub fn new(stats: Stats, last_update: Instant) -> Self {
+        Self {
+            stats,
+            last_update,
+        }
+    }
+
+    pub fn stats(&self) -> &Stats {
+        &self.stats
+    }
+
+    pub fn last_update(&self) -> Instant {
+        self.last_update
+    }
+}
+
+
+pub struct StatsCache {
+    ttl: Duration,
+    stats: Arc<RwLock<Option<CachedStats>>>,
+}
+
+impl StatsCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            stats: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub async fn update(&self, stats: Stats) {
+        let mut stats_lock = self.stats.write().await;
+        match &mut *stats_lock {
+            Some(curr_stats) => {
+                curr_stats.stats = stats;
+                curr_stats.last_update = Instant::now();
+            }
+            None => {
+                *stats_lock = Some(CachedStats::new(stats, Instant::now()));
+            }
+        }
+    }
+
+    pub async fn stats(&self) -> Option<Stats> {
+        let lock = self.stats.read().await;
+        if lock.is_some() && Instant::now().duration_since(lock.as_ref()?.last_update) > self.ttl {
+            let mut lock = self.stats.write().await;
+            *lock = None;
+            return None;
+        }
+        (*lock).as_ref().map(|cached_stats| cached_stats.stats.clone())
+    }
+}
+

--- a/src/server/http/stats/mod.rs
+++ b/src/server/http/stats/mod.rs
@@ -15,3 +15,4 @@ pub fn algo_stat_key(algo: PowAlgorithm, stat_key: &str) -> String {
 
 pub mod handlers;
 pub mod models;
+pub mod cache;

--- a/src/server/http/stats/mod.rs
+++ b/src/server/http/stats/mod.rs
@@ -13,6 +13,6 @@ pub fn algo_stat_key(algo: PowAlgorithm, stat_key: &str) -> String {
     format!("{}_{}", algo.to_string().to_lowercase(), stat_key)
 }
 
+pub mod cache;
 pub mod handlers;
 pub mod models;
-pub mod cache;

--- a/src/server/http/stats/models.rs
+++ b/src/server/http/stats/models.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 
-use num::BigUint;
 use serde::{Deserialize, Serialize};
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_utilities::epoch_time::EpochTime;
@@ -11,7 +10,7 @@ use tari_utilities::hex::Hex;
 
 use crate::sharechain::block::Block;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct StatsBlock {
     pub hash: String,
     pub height: u64,
@@ -30,7 +29,7 @@ impl From<Block> for StatsBlock {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct EstimatedEarnings {
     #[serde(rename = "1min")]
     pub one_minute: MicroMinotari,
@@ -56,7 +55,7 @@ impl EstimatedEarnings {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BlockStats {
     pub accepted: u64,
     pub rejected: u64,
@@ -73,7 +72,7 @@ impl BlockStats {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct TribeDetails {
     pub id: String,
     pub name: String,
@@ -84,7 +83,7 @@ impl TribeDetails {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Stats {
     pub connected: bool,
     pub connected_since: Option<EpochTime>,
@@ -92,7 +91,7 @@ pub struct Stats {
     pub num_of_miners: usize,
     pub last_block_won: Option<StatsBlock>,
     pub share_chain_height: u64,
-    pub pool_hash_rate: BigUint,
+    pub pool_hash_rate: String,
     pub pool_total_earnings: MicroMinotari,
     pub pool_total_estimated_earnings: EstimatedEarnings,
     pub total_earnings: HashMap<String, u64>,

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -570,6 +570,7 @@ where
                 debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Found highest known block height: {result:?}");
                 debug!(target: LOG_TARGET, tribe = &self.config.tribe; "Send share chain sync request: {result:?}");
                 // we always send from_height as zero now, to not miss any blocks
+                info!(target: LOG_TARGET, "[{:?}] Syncing share chain...", algo);
                 self.swarm
                     .behaviour_mut()
                     .share_chain_sync
@@ -577,7 +578,7 @@ where
             },
             None => {
                 self.sync_in_progress.store(false, Ordering::SeqCst);
-                error!(target: LOG_TARGET, tribe = &self.config.tribe; "Failed to get peer with highest share chain height!")
+                error!(target: LOG_TARGET, tribe = &self.config.tribe; "[{:?}] Failed to get peer with highest share chain height!", algo)
             },
         }
     }
@@ -610,12 +611,26 @@ where
                     return;
                 }
                 else => {
+                    let mut sha3_ready = false;
                     if let Some(result) = peer_store.tip_of_block_height(PowAlgorithm::Sha3x).await {
                         if let Ok(tip) = share_chain_sha3x.tip_height().await {
                             if tip < result.height {
-                                break;
+                                sha3_ready = true;
                             }
                         }
+                    }
+
+                    let mut randomx_ready = false;
+                    if let Some(result) = peer_store.tip_of_block_height(PowAlgorithm::RandomX).await {
+                        if let Ok(tip) = share_chain_random_x.tip_height().await {
+                            if tip < result.height {
+                                randomx_ready = true;
+                            }
+                        }
+                    }
+
+                    if sha3_ready && randomx_ready {
+                        break;
                     }
                 }
             }

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -48,6 +48,7 @@ use tokio::{
 };
 
 use crate::server::p2p::messages::LocalShareChainSyncRequest;
+use crate::sharechain::block::CURRENT_CHAIN_ID;
 use crate::{
     server::{
         config,
@@ -392,7 +393,7 @@ where
     /// blocks and peers with different Tari networks and the given tribe name.
     fn tribe_topic(tribe: &Tribe, topic: &str) -> String {
         let network = Network::get_current_or_user_setting_or_default().as_key_str();
-        format!("{network}_{tribe}_{topic}")
+        format!("{network}_{}_{tribe}_{topic}", CURRENT_CHAIN_ID.clone())
     }
 
     /// Subscribing to a gossipsub topic.

--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -386,14 +386,16 @@ where
     /// blocks and peers with different Tari networks.
     fn network_topic(topic: &str) -> String {
         let network = Network::get_current_or_user_setting_or_default().as_key_str();
-        format!("{network}_{topic}")
+        let chain_id = CURRENT_CHAIN_ID.clone();
+        format!("{network}_{chain_id}_{topic}")
     }
 
     /// Generates a gossip sub topic name based on the current Tari network to avoid mixing up
     /// blocks and peers with different Tari networks and the given tribe name.
     fn tribe_topic(tribe: &Tribe, topic: &str) -> String {
         let network = Network::get_current_or_user_setting_or_default().as_key_str();
-        format!("{network}_{}_{tribe}_{topic}", CURRENT_CHAIN_ID.clone())
+        let chain_id = CURRENT_CHAIN_ID.clone();
+        format!("{network}_{chain_id}_{tribe}_{topic}")
     }
 
     /// Subscribing to a gossipsub topic.

--- a/src/server/p2p/peer_store.rs
+++ b/src/server/p2p/peer_store.rs
@@ -1,15 +1,15 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use itertools::Itertools;
+use libp2p::PeerId;
+use log::{debug, info, warn};
+use moka::future::{Cache, CacheBuilder};
+use std::ops::Add;
 use std::{
     sync::RwLock,
     time::{Duration, Instant},
 };
-
-use itertools::Itertools;
-use libp2p::PeerId;
-use log::{debug, warn};
-use moka::future::{Cache, CacheBuilder};
 use tari_core::proof_of_work::PowAlgorithm;
 use tari_utilities::epoch_time::EpochTime;
 
@@ -17,16 +17,19 @@ use crate::server::p2p::messages::PeerInfo;
 use crate::server::p2p::Tribe;
 
 const LOG_TARGET: &str = "p2pool::server::p2p::peer_store";
+const PEER_BAN_TIME: Duration = Duration::from_secs(60 * 5);
 
 #[derive(Copy, Clone, Debug)]
 pub struct PeerStoreConfig {
     pub peer_record_ttl: Duration,
+    pub peers_max_fail: u64,
 }
 
 impl Default for PeerStoreConfig {
     fn default() -> Self {
         Self {
             peer_record_ttl: Duration::from_secs(10),
+            peers_max_fail: 2,
         }
     }
 }
@@ -66,12 +69,15 @@ pub struct PeerStore {
     peers: Cache<PeerId, PeerStoreRecord>,
     /// Max time to live for the items to avoid non-existing peers in list.
     ttl: Duration,
+    peers_max_fail: u64,
     /// Peer with the highest share chain height in SHA-3 share chain.
     tip_of_block_height_sha3x: RwLock<Option<PeerStoreBlockHeightTip>>,
     /// Peer with the highest share chain height in RandomX share chain.
     tip_of_block_height_random_x: RwLock<Option<PeerStoreBlockHeightTip>>,
     /// The last time when we had more than 0 peers.
     last_connected: RwLock<Option<EpochTime>>,
+    peer_removals: Cache<PeerId, u64>,
+    banned_peers: Cache<PeerId, ()>,
 }
 
 impl PeerStore {
@@ -80,16 +86,28 @@ impl PeerStore {
         Self {
             peers: CacheBuilder::new(100_000).time_to_live(config.peer_record_ttl).build(),
             ttl: config.peer_record_ttl,
+            peers_max_fail: config.peers_max_fail,
             tip_of_block_height_sha3x: RwLock::new(None),
             tip_of_block_height_random_x: RwLock::new(None),
             last_connected: RwLock::new(None),
+            peer_removals: CacheBuilder::new(100_000).time_to_live(config.peer_record_ttl).build(),
+            banned_peers: CacheBuilder::new(100_000).time_to_live(PEER_BAN_TIME).build(),
         }
     }
 
     /// Add a new peer to store.
     /// If a peer already exists, just replaces it.
     pub async fn add(&self, peer_id: PeerId, peer_info: PeerInfo) {
-        self.peers.insert(peer_id, PeerStoreRecord::new(peer_info)).await;
+        let removal_count = self.peer_removals.get(&peer_id).await.unwrap_or(0);
+        if removal_count >= self.peers_max_fail {
+            warn!("Banning peer {peer_id:?} for {:?}!", PEER_BAN_TIME);
+            self.peer_removals.remove(&peer_id).await;
+            self.banned_peers.insert(peer_id, ()).await;
+        } else {
+            self.peers.insert(peer_id, PeerStoreRecord::new(peer_info)).await;
+            self.peer_removals.insert(peer_id, removal_count).await;
+        }
+
         self.set_tip_of_block_heights().await;
         self.set_last_connected().await;
     }
@@ -97,6 +115,25 @@ impl PeerStore {
     /// Removes a peer from store.
     pub async fn remove(&self, peer_id: &PeerId) {
         self.peers.remove(peer_id).await;
+
+        // counting peer removals
+        let removal_count = match self.peer_removals.get(peer_id).await {
+            Some(value) => {
+                let removals = value + 1;
+                self.peer_removals.insert(*peer_id, removals).await;
+                removals
+            },
+            None => {
+                self.peer_removals.insert(*peer_id, 1).await;
+                1
+            },
+        };
+        if removal_count >= self.peers_max_fail {
+            warn!("Banning peer {peer_id:?} for {:?}!", PEER_BAN_TIME);
+            self.peer_removals.remove(peer_id).await;
+            self.banned_peers.insert(*peer_id, ()).await;
+        }
+
         self.set_tip_of_block_heights().await;
         self.set_last_connected().await;
     }
@@ -128,17 +165,22 @@ impl PeerStore {
             PowAlgorithm::RandomX => &self.tip_of_block_height_random_x,
             PowAlgorithm::Sha3x => &self.tip_of_block_height_sha3x,
         };
-        if let Some((k, v)) = self.peers.iter().max_by(|(_k1, v1), (_k2, v2)| {
-            let current_height_v1 = match pow {
-                PowAlgorithm::RandomX => v1.peer_info.current_random_x_height,
-                PowAlgorithm::Sha3x => v1.peer_info.current_sha3x_height,
-            };
-            let current_height_v2 = match pow {
-                PowAlgorithm::RandomX => v2.peer_info.current_random_x_height,
-                PowAlgorithm::Sha3x => v2.peer_info.current_sha3x_height,
-            };
-            current_height_v1.cmp(&current_height_v2)
-        }) {
+        if let Some((k, v)) = self
+            .peers
+            .iter()
+            .filter(|(peer_id, _)| !self.banned_peers.contains_key(peer_id))
+            .max_by(|(_k1, v1), (_k2, v2)| {
+                let current_height_v1 = match pow {
+                    PowAlgorithm::RandomX => v1.peer_info.current_random_x_height,
+                    PowAlgorithm::Sha3x => v1.peer_info.current_sha3x_height,
+                };
+                let current_height_v2 = match pow {
+                    PowAlgorithm::RandomX => v2.peer_info.current_random_x_height,
+                    PowAlgorithm::Sha3x => v2.peer_info.current_sha3x_height,
+                };
+                current_height_v1.cmp(&current_height_v2)
+            })
+        {
             // save result
             if let Ok(mut tip_height_opt) = tip_of_block.write() {
                 let current_height = match pow {

--- a/src/server/p2p/peer_store.rs
+++ b/src/server/p2p/peer_store.rs
@@ -3,9 +3,8 @@
 
 use itertools::Itertools;
 use libp2p::PeerId;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use moka::future::{Cache, CacheBuilder};
-use std::ops::Add;
 use std::{
     sync::RwLock,
     time::{Duration, Instant},

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -4,7 +4,6 @@
 use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 use std::{
     net::{AddrParseError, SocketAddr},
     str::FromStr,
@@ -113,7 +112,7 @@ where
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 
-        let http_stats_cache = Arc::new(StatsCache::new(Duration::from_secs(10)));
+        let http_stats_cache = Arc::new(StatsCache::default());
 
         let stats_server = if config.http_server.enabled {
             Some(Arc::new(HttpServer::new(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -82,8 +82,8 @@ where
             sync_in_progress.clone(),
             shutdown_signal.clone(),
         )
-            .await
-            .map_err(Error::P2PService)?;
+        .await
+        .map_err(Error::P2PService)?;
 
         let mut base_node_grpc_server = None;
         let mut p2pool_server = None;
@@ -108,8 +108,8 @@ where
                 consensus_manager,
                 genesis_block_hash,
             )
-                .await
-                .map_err(Error::Grpc)?;
+            .await
+            .map_err(Error::Grpc)?;
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -113,7 +113,7 @@ where
             p2pool_server = Some(ShaP2PoolServer::new(p2pool_grpc_service));
         }
 
-        let http_stats_cache = Arc::new(StatsCache::new(Duration::from_secs(30))); // TODO: update
+        let http_stats_cache = Arc::new(StatsCache::new(Duration::from_secs(10)));
 
         let stats_server = if config.http_server.enabled {
             Some(Arc::new(HttpServer::new(

--- a/src/sharechain/in_memory.rs
+++ b/src/sharechain/in_memory.rs
@@ -115,16 +115,16 @@ impl InMemoryShareChain {
                         params.genesis_block_hash(),
                         params.consensus_manager(),
                     )
-                        .map_err(Error::RandomXDifficulty)?;
+                    .map_err(Error::RandomXDifficulty)?;
                     Ok(difficulty.as_u64())
                 } else {
                     Ok(0)
                 }
-            }
+            },
             PowAlgorithm::Sha3x => {
                 let difficulty = sha3x_difficulty(block.original_block_header()).map_err(Error::Difficulty)?;
                 Ok(difficulty.as_u64())
-            }
+            },
         }
     }
 
@@ -212,11 +212,11 @@ impl InMemoryShareChain {
                             debug!(target: LOG_TARGET, "Failed to calculate RandomX difficulty: {error:?}");
                             return Ok(ValidateBlockResult::new(false, false));
                         }
-                    }
+                    },
                     None => {
                         error!(target: LOG_TARGET, "❌ Cannot calculate PoW! Missing validation parameters!");
                         return Ok(ValidateBlockResult::new(false, false));
-                    }
+                    },
                 },
                 PowAlgorithm::Sha3x => {
                     if let Err(error) = sha3x_difficulty(block.original_block_header()) {
@@ -224,7 +224,7 @@ impl InMemoryShareChain {
                         debug!(target: LOG_TARGET, "Failed to calculate SHA3x difficulty: {error:?}");
                         return Ok(ValidateBlockResult::new(false, false));
                     }
-                }
+                },
             }
 
             // TODO: check here for miners

--- a/src/sharechain/in_memory.rs
+++ b/src/sharechain/in_memory.rs
@@ -493,7 +493,7 @@ impl ShareChain for InMemoryShareChain {
         for block in blocks {
             let difficulty = self.block_difficulty(&block)?;
             let current_hash_rate = difficulty as f64 / avg_block_time;
-            hash_rates_sum = hash_rates_sum.add(u64::try_from(current_hash_rate)?); // TODO: fix
+            hash_rates_sum = hash_rates_sum.add(current_hash_rate as u64);
             hash_rates_count.inc();
         }
 

--- a/src/sharechain/in_memory.rs
+++ b/src/sharechain/in_memory.rs
@@ -115,16 +115,16 @@ impl InMemoryShareChain {
                         params.genesis_block_hash(),
                         params.consensus_manager(),
                     )
-                    .map_err(Error::RandomXDifficulty)?;
+                        .map_err(Error::RandomXDifficulty)?;
                     Ok(difficulty.as_u64())
                 } else {
                     Ok(0)
                 }
-            },
+            }
             PowAlgorithm::Sha3x => {
                 let difficulty = sha3x_difficulty(block.original_block_header()).map_err(Error::Difficulty)?;
                 Ok(difficulty.as_u64())
-            },
+            }
         }
     }
 
@@ -212,11 +212,11 @@ impl InMemoryShareChain {
                             debug!(target: LOG_TARGET, "Failed to calculate RandomX difficulty: {error:?}");
                             return Ok(ValidateBlockResult::new(false, false));
                         }
-                    },
+                    }
                     None => {
                         error!(target: LOG_TARGET, "❌ Cannot calculate PoW! Missing validation parameters!");
                         return Ok(ValidateBlockResult::new(false, false));
-                    },
+                    }
                 },
                 PowAlgorithm::Sha3x => {
                     if let Err(error) = sha3x_difficulty(block.original_block_header()) {
@@ -224,7 +224,7 @@ impl InMemoryShareChain {
                         debug!(target: LOG_TARGET, "Failed to calculate SHA3x difficulty: {error:?}");
                         return Ok(ValidateBlockResult::new(false, false));
                     }
-                },
+                }
             }
 
             // TODO: check here for miners
@@ -446,15 +446,15 @@ impl ShareChain for InMemoryShareChain {
             return Ok(BigUint::zero());
         }
 
-        let avg_block_time = BigUint::from(block_times_sum).div(BigUint::from(block_times_count));
+        let avg_block_time: f64 = (block_times_sum / block_times_count) as f64;
 
         // collect all hash rates
         let mut hash_rates_sum = BigUint::zero();
         let mut hash_rates_count = BigUint::zero();
         for block in blocks {
             let difficulty = self.block_difficulty(&block)?;
-            let current_hash_rate = BigUint::from(difficulty).div(avg_block_time.clone());
-            hash_rates_sum = hash_rates_sum.add(current_hash_rate);
+            let current_hash_rate = difficulty as f64 / avg_block_time;
+            hash_rates_sum = hash_rates_sum.add(current_hash_rate as u64);
             hash_rates_count.inc();
         }
 

--- a/src/sharechain/in_memory.rs
+++ b/src/sharechain/in_memory.rs
@@ -115,16 +115,16 @@ impl InMemoryShareChain {
                         params.genesis_block_hash(),
                         params.consensus_manager(),
                     )
-                    .map_err(Error::RandomXDifficulty)?;
+                        .map_err(Error::RandomXDifficulty)?;
                     Ok(difficulty.as_u64())
                 } else {
                     Ok(0)
                 }
-            },
+            }
             PowAlgorithm::Sha3x => {
                 let difficulty = sha3x_difficulty(block.original_block_header()).map_err(Error::Difficulty)?;
                 Ok(difficulty.as_u64())
-            },
+            }
         }
     }
 
@@ -178,12 +178,12 @@ impl InMemoryShareChain {
                     warn!(target: LOG_TARGET, "[{:?}] ❌ Too low difficulty!", self.pow_algo);
                     return Ok(ValidateBlockResult::new(false, false));
                 }
-            },
+            }
             Err(error) => {
                 warn!(target: LOG_TARGET, "[{:?}] ❌ Can't get min difficulty!", self.pow_algo);
                 debug!(target: LOG_TARGET, "[{:?}] ❌ Can't get min difficulty: {error:?}", self.pow_algo);
                 return Ok(ValidateBlockResult::new(false, false));
-            },
+            }
         }
 
         Ok(ValidateBlockResult::new(true, false))
@@ -237,18 +237,18 @@ impl InMemoryShareChain {
                                 if !result.valid {
                                     return Ok(result);
                                 }
-                            },
+                            }
                             Err(error) => {
                                 warn!(target: LOG_TARGET, "[{:?}] ❌ Invalid PoW!", self.pow_algo);
                                 debug!(target: LOG_TARGET, "[{:?}] Failed to calculate RandomX difficulty: {error:?}", self.pow_algo);
                                 return Ok(ValidateBlockResult::new(false, false));
-                            },
+                            }
                         }
-                    },
+                    }
                     None => {
                         error!(target: LOG_TARGET, "[{:?}] ❌ Cannot calculate PoW! Missing validation parameters!", self.pow_algo);
                         return Ok(ValidateBlockResult::new(false, false));
-                    },
+                    }
                 },
                 PowAlgorithm::Sha3x => match sha3x_difficulty(block.original_block_header()) {
                     Ok(curr_difficulty) => {
@@ -256,12 +256,12 @@ impl InMemoryShareChain {
                         if !result.valid {
                             return Ok(result);
                         }
-                    },
+                    }
                     Err(error) => {
                         warn!(target: LOG_TARGET, "[{:?}] ❌ Invalid PoW!", self.pow_algo);
                         debug!(target: LOG_TARGET, "[{:?}] Failed to calculate SHA3x difficulty: {error:?}", self.pow_algo);
                         return Ok(ValidateBlockResult::new(false, false));
-                    },
+                    }
                 },
             }
 
@@ -493,7 +493,7 @@ impl ShareChain for InMemoryShareChain {
         for block in blocks {
             let difficulty = self.block_difficulty(&block)?;
             let current_hash_rate = difficulty as f64 / avg_block_time;
-            hash_rates_sum = hash_rates_sum.add(current_hash_rate as u64);
+            hash_rates_sum = hash_rates_sum.add(u64::try_from(current_hash_rate)?); // TODO: fix
             hash_rates_count.inc();
         }
 

--- a/src/sharechain/mod.rs
+++ b/src/sharechain/mod.rs
@@ -9,6 +9,10 @@ use tari_common_types::types::FixedHash;
 use tari_core::consensus::ConsensusManager;
 use tari_core::proof_of_work::randomx_factory::RandomXFactory;
 
+/// Chain ID is an identifier which makes sure we apply the same rules to blocks.
+/// Note: This must be updated when new logic applied to blocks handling.
+pub const CHAIN_ID: usize = 1;
+
 /// How many blocks to keep overall.
 pub const MAX_BLOCKS_COUNT: usize = 240;
 

--- a/src/sharechain/mod.rs
+++ b/src/sharechain/mod.rs
@@ -15,7 +15,7 @@ pub const MAX_BLOCKS_COUNT: usize = 240;
 /// How many blocks are used to calculate current shares to be paid out.
 pub const BLOCKS_WINDOW: usize = 80;
 
-pub const SHARE_COUNT: u64 = 2096;
+pub const SHARE_COUNT: u64 = 200;
 
 pub mod block;
 pub mod error;


### PR DESCRIPTION
Description
---
- Set share count to `200` for both algorithms.
- Add rate limiting to miner, it cannot send more than half of the shares.
- Fix HTTP stats
- Initialize Chain ID logic
- Minimum target difficulty based on network constants

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
