### PR TITLE
fix: fixed http stats caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "sha_p2pool"
-version = "0.1.5-pre.5"
+version = "0.1.5-pre.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha_p2pool"
-version = "0.1.5-pre.5"
+version = "0.1.5-pre.6"
 edition = "2021"
 
 [dependencies]

--- a/src/server/http/stats/handlers.rs
+++ b/src/server/http/stats/handlers.rs
@@ -43,7 +43,7 @@ pub async fn handle_get_stats(State(state): State<AppState>) -> Result<Json<Hash
 async fn get_stats(state: AppState, algo: PowAlgorithm) -> Result<Stats, StatusCode> {
     // return from cache if possible
     let stats_cache = state.stats_cache.clone();
-    if let Some(stats) = stats_cache.stats().await {
+    if let Some(stats) = stats_cache.stats(algo).await {
         return Ok(stats);
     }
 
@@ -171,7 +171,7 @@ async fn get_stats(state: AppState, algo: PowAlgorithm) -> Result<Stats, StatusC
         tribe: TribeDetails::new(state.tribe.to_string(), state.tribe.formatted()),
     };
 
-    stats_cache.update(result.clone()).await;
+    stats_cache.update(result.clone(), algo).await;
 
     Ok(result)
 }


### PR DESCRIPTION
Description
---
By mistake SHA3 stats were returned for both RandomX, this is fixed in this PR.

Motivation and Context
---
Http stats are cached in memory (to avoid too much stress on in memory share chain).

How Has This Been Tested?
---
- Start P2Pool
- Wait for syncing
- Check stats whether they are the same or not (should not)

What process can a PR reviewer use to test or verify this change?
---
See tests.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
