### PR TITLE
feat(list-tribes): add configurable timeout to list-tribes command

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -98,6 +98,16 @@ pub struct StartArgs {
     pub http_server_disabled: bool,
 }
 
+#[derive(Clone, Parser, Debug)]
+pub struct ListTribeArgs {
+    /// List tribe command timeout in seconds.
+    ///
+    /// The list-tribes commands tries to look for all the currently available tribes
+    /// for this amount of time maximum.
+    #[arg(long, value_name = "timeout", default_value_t = 30)]
+    pub timeout: u64,
+}
+
 #[derive(Subcommand, Clone, Debug)]
 pub enum Commands {
     /// Starts sha-p2pool node.
@@ -113,6 +123,9 @@ pub enum Commands {
     ListTribes {
         #[clap(flatten)]
         args: StartArgs,
+
+        #[clap(flatten)]
+        list_tribe_args: ListTribeArgs,
     },
 }
 
@@ -133,7 +146,10 @@ impl Cli {
                 .clone()
                 .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/p2pool")),
             Commands::GenerateIdentity => dirs::home_dir().unwrap().join(".tari/p2pool"),
-            Commands::ListTribes { args } => args
+            Commands::ListTribes {
+                args,
+                list_tribe_args: _list_tribe_args,
+            } => args
                 .base_dir
                 .clone()
                 .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/p2pool")),
@@ -153,8 +169,8 @@ impl Cli {
             Commands::GenerateIdentity => {
                 commands::handle_generate_identity().await?;
             },
-            Commands::ListTribes { args } => {
-                commands::handle_list_tribes(cli_ref.clone(), args, cli_shutdown.clone()).await?;
+            Commands::ListTribes { args, list_tribe_args } => {
+                commands::handle_list_tribes(cli_ref.clone(), args, list_tribe_args, cli_shutdown.clone()).await?;
             },
         }
 

--- a/src/cli/commands/list_tribes.rs
+++ b/src/cli/commands/list_tribes.rs
@@ -11,13 +11,14 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::{select, time};
 
-use crate::cli::args::{Cli, StartArgs};
+use crate::cli::args::{Cli, ListTribeArgs, StartArgs};
 use crate::cli::commands::util;
 use crate::server::p2p::peer_store::PeerStore;
 
 pub async fn handle_list_tribes(
     cli: Arc<Cli>,
     args: &StartArgs,
+    list_tribe_args: &ListTribeArgs,
     cli_shutdown_signal: ShutdownSignal,
 ) -> anyhow::Result<()> {
     // start server asynchronously
@@ -41,9 +42,9 @@ pub async fn handle_list_tribes(
     // wait for peer store from started server
     let peer_store = peer_store_channel_rx.await?;
 
-    // collect tribes for 30 seconds
+    // collect tribes for the given timeout
     let mut tribes = vec![];
-    let timeout = time::sleep(Duration::from_secs(30));
+    let timeout = time::sleep(Duration::from_secs(list_tribe_args.timeout));
     tokio::pin!(timeout);
     tokio::pin!(cli_shutdown_signal);
     loop {


### PR DESCRIPTION
Description
---
Until now the `list-tribes` command was trying to collect all the tribes within fixed 30 seconds. Now with this change it is configurable via cli using `--timeout` where you can set the timeout as seconds.

Motivation and Context
---

How Has This Been Tested?
---
`sha_p2pool list-tribes --timeout 5` - within 5 seconds it is listing currently known tribes.

What process can a PR reviewer use to test or verify this change?
---
See test.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
