### PR TITLE
feat: remove achieved difficulty calculation and submit block to base node

### DIFF
--- a/src/server/grpc/p2pool.rs
+++ b/src/server/grpc/p2pool.rs
@@ -342,7 +342,7 @@ where S: ShareChain
             block.hash
         );
         // TODO: Cache this so that we don't ask each time. If we have a block we should not
-        // waste time before submitting it, or we might lose a share
+        // TODO: waste time before submitting it, or we might lose a share
         // let mut network_difficulty_stream = self
         //     .client
         //     .lock()


### PR DESCRIPTION
Description
---
Removed achieved difficulty calculation and submit block to base node, as this will be done by the respective miners/merge mining proxy.

Motivation and Context
---
It is not efficient for the sha-p2pool to recalculate difficulty nor to submit the mined block with appropriate achieved difficulty to the base node, as the miners already calculate the achieved difficulty and can submit the block directly to the base node instead of via a 3rd party (the sha-p2pool in this case).

How Has This Been Tested?
---
Waiting for system-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: 
- Miners must submit blocks with appropriate achieved difficulty to the base node directly before submitting it to the sha-p2pool.
- gRPC `GetNewBlockResponse` interface change.
