### PR TITLE
fix: handling of uncle blocks

### DIFF
--- a/src/server/p2p/network.rs
+++ b/src/server/p2p/network.rs
@@ -626,7 +626,7 @@ where S: ShareChain
                 //     return;
                 // }
                 match NotifyNewTipBlock::try_from(message) {
-                    Ok(mut payload) => {
+                    Ok(payload) => {
                         if payload.version < MIN_NOTIFY_VERSION {
                             debug!(target: LOG_TARGET, squad = &self.config.squad; "Peer {} has an outdated version, skipping", peer);
                             return;


### PR DESCRIPTION
Description
---
Limits uncles to max 10 per block
only include uncle block if it links back to main chain
fix verification of uncles