### PR TITLE
chore(ci): minor ci fixes - bump osx x64 target

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "macos-x86_64",
-    "runs-on": "macos-12",
+    "runs-on": "macos-13",
     "rust": "stable",
     "target": "x86_64-apple-darwin",
     "cross": false

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -180,6 +180,7 @@ jobs:
           # Should already be installed
           # choco upgrade strawberryperl -y
           choco upgrade protoc -y
+          rustup target add ${{ matrix.builds.target }}
 
       - name: Set environment variables - Nix
         if: ${{ ! startsWith(runner.os,'Windows') }}


### PR DESCRIPTION
Description
Bump osx x64 target image builder

Motivation and Context
Fix OSX x64 builds, as GH have deprecation the target

How Has This Been Tested?
Builds in local fork
