### PR TITLE
chore: always use p2p difficulty to mine even if we mine solo

### DIFF
--- a/src/server/grpc/p2pool.rs
+++ b/src/server/grpc/p2pool.rs
@@ -309,7 +309,7 @@ where S: ShareChain
                 }
 
                 // what happens p2pool difficulty > base chain diff
-                if target_difficulty.as_u64() < miner_data.target_difficulty && synced_status {
+                if target_difficulty.as_u64() < miner_data.target_difficulty {
                     miner_data.target_difficulty = target_difficulty.as_u64();
                 }
             }


### PR DESCRIPTION
Description
---
Currently when we mine solo, the miner gets the full tari difficulty. Although this is correct, it can cause the miner to check in less with p2pool. If we are synced with p2pool we should start mining on the p2pool blocks as soon as possible again. Not wait till we mine a tari block or the template changes. This should make very little difference on the mining power, but will cause the miner to check in with p2pool more frequently 