### PR TITLE
chore(ci): for osx force openssl static

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -196,6 +196,17 @@ jobs:
         run: |
           echo "PLATFORM_SPECIFIC_DIR=osx" >> $GITHUB_ENV
           echo "LIB_EXT=.dylib" >> $GITHUB_ENV
+          # Force static openssl libs
+          echo "OPENSSL_STATIC=1" >> $GITHUB_ENV
+          if [ -f /opt/homebrew/opt/openssl/README.md ]; then
+            ls -la /opt/homebrew/opt/openssl/
+            echo "OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl/lib" >> $GITHUB_ENV
+            echo "OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl/include" >> $GITHUB_ENV
+          else
+            ls -la /usr/local/opt/openssl/
+            echo "OPENSSL_LIB_DIR=/usr/local/opt/openssl/lib" >> $GITHUB_ENV
+            echo "OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include" >> $GITHUB_ENV
+          fi
 
       # Hardcoded sdk for MacOSX on ARM64
       - name: Set environment variables - macOS - ARM64 (pin/sdk)


### PR DESCRIPTION
Description
OSX force openssl static

Motivation and Context
Remove the need to install openssl via brew

How Has This Been Tested?
Builds locally
