### PR TITLE
chore(ci): merge clippy/machete/vet into one step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clippy:
-    name: clippy
+  ci:
+    name: ci
     runs-on: [ ubuntu-latest ]
     steps:
       - name: checkout
@@ -71,45 +71,15 @@ jobs:
         run: cargo install cargo-lints
       - name: Clippy check (with lints)
         run: cargo +${{ env.toolchain }} lints clippy --all-targets --all-features
-
-  machete:
-    # Checks for unused dependencies.
-    name: machete
-    runs-on: [ ubuntu-20.04 ]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.toolchain }}
-          components: clippy, rustfmt
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
-      - name: caching (machete)
-        # Don't use rust-cache.
-        # Rust-cache disables a key feature of actions/cache: restoreKeys.
-        # Without restore keys, we lose the ability to get partial matches on caches, and end
-        # up with too many cache misses.
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/CACHEDIR.TAG
-            ~/.cargo/git
-            target
-          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}-small
-          restore-keys: |
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}-small
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly
       - name: cargo machete
         run: |
-          cargo install cargo-machete@0.7.0
+          cargo install cargo-machete@0.7.0 --locked
           cargo machete
+      - name: cargo vet
+        run: |
+          cargo install cargo-vet@0.10.0 --locked
+          cargo vet
+
   build-stable:
     # Runs cargo check with stable toolchain to determine whether the codebase is likely to build
     #  on stable Rust.


### PR DESCRIPTION
Description
Merge clippy/machete/vet into one step

Motivation and Context
No need to spend extra resources on tests that can be run together

How Has This Been Tested?
Runs in local fork - vet still needs to be setup