### PR TITLE
fix: reorg lwma calculation bug

### DIFF
--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -463,7 +463,6 @@ impl<T: BlockCache> P2Chain<T> {
                 // lets start by resetting the lwma
                 self.lwma = LinearWeightedMovingAverage::new(DIFFICULTY_ADJUSTMENT_WINDOW, self.block_time)
                     .expect("Failed to create LWMA");
-                self.lwma.add_front(block.timestamp, block.target_difficulty);
                 let chain_height = self
                     .level_at_height(block.height)
                     .ok_or(ShareChainError::BlockLevelNotFound)?;


### PR DESCRIPTION
Description
---
Fixes a bug on reorg where the tip block will be counted twice during a reorg when insterting into the lwma. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for updating the latest block tip, enhancing internal consistency while ensuring no visible changes to the user interface or public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->