### PR TITLE
feat: add diagnostic mode

### DIFF
--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -111,8 +111,8 @@ async fn spawn_base_node_with_config(
         base_node_identity = node_ps.identity.clone();
     } else {
         // each spawned base node will use different ports
-        bn_port = get_port(18000..18499, Duration::from_secs(20)).ok_or("bn_port no free port")?;
-        grpc_port = get_port(18500..18999, Duration::from_secs(20)).ok_or("grpc_port no free port")?;
+        bn_port = get_port(world, 18000..18499, Duration::from_secs(20)).ok_or("bn_port no free port")?;
+        grpc_port = get_port(world, 18500..18999, Duration::from_secs(20)).ok_or("grpc_port no free port")?;
         // create a new temporary directory
         temp_dir_path = world
             .current_base_dir

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -8,6 +8,7 @@ pub mod miner;
 pub mod world;
 
 use std::{
+    collections::HashSet,
     net::TcpListener,
     ops::Range,
     path::PathBuf,
@@ -21,15 +22,26 @@ pub use world::TariWorld;
 
 type TestResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-pub fn get_port(range: Range<u16>, time_out: Duration) -> Option<u16> {
+pub fn get_port(world: &TariWorld, range: Range<u16>, time_out: Duration) -> Option<u16> {
     let min = range.clone().min().expect("A minimum possible port number");
     let max = range.max().expect("A maximum possible port number");
+
+    // Collect all used ports in the world
+    let mut used_ports = HashSet::new();
+    for node in world.p2pool_nodes.values() {
+        used_ports.insert(node.grpc_port);
+        used_ports.insert(node.p2p_port);
+    }
+    for node in world.base_nodes.values() {
+        used_ports.insert(node.port);
+        used_ports.insert(node.grpc_port);
+    }
 
     let start = Instant::now();
     loop {
         let port = rand::thread_rng().gen_range(min..max);
 
-        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+        if !used_ports.contains(&port) && TcpListener::bind(("127.0.0.1", port)).is_ok() {
             return Some(port);
         }
         if start.elapsed() > time_out {

--- a/integration_tests/src/p2pool_process.rs
+++ b/integration_tests/src/p2pool_process.rs
@@ -88,13 +88,14 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
             node_config.network_silence_delay = 0;
         }
         // Each spawned p2pool node will use different ports
-        node_config.p2p_port = get_port(18000..18499, Duration::from_secs(20)).ok_or("p2p_port no free port")?;
-        node_config.grpc_port = get_port(18500..18999, Duration::from_secs(20)).ok_or("grpc_port no free port")?;
+        node_config.p2p_port = get_port(world, 18000..18499, Duration::from_secs(20)).ok_or("p2p_port no free port")?;
+        node_config.grpc_port =
+            get_port(world, 18500..18999, Duration::from_secs(20)).ok_or("grpc_port no free port")?;
         if is_seed_node {
             node_config.http_server.enabled = false;
         } else {
             node_config.http_server.port =
-                get_port(19000..19499, Duration::from_secs(20)).ok_or("http_server_port no free port")?;
+                get_port(world, 19000..19499, Duration::from_secs(20)).ok_or("http_server_port no free port")?;
             node_config.http_server.enabled = true;
         }
         // The format for this addrress can be either "/ip4/127.0.0.1/tcp/{}" or "/ip4/127.0.0.1/udp/{}/quic-v1"

--- a/integration_tests/src/p2pool_process.rs
+++ b/integration_tests/src/p2pool_process.rs
@@ -35,6 +35,7 @@ pub struct P2PoolProcess {
     pub name: String,
     pub temp_dir_path: PathBuf,
     pub is_seed_node: bool,
+    pub diagnostic_mode: bool,
     pub config: ShaP2PoolConfig,
     pub node_id: PeerId,
     pub squad: String,
@@ -54,6 +55,7 @@ impl Drop for P2PoolProcess {
 pub async fn spawn_p2pool_node_and_wait_for_start(
     world: &mut TariWorld,
     is_seed_node: bool,
+    diagnostic_mode: bool,
     p2pool_name: String,
     squad: String,
     connected_base_node: String,
@@ -61,6 +63,7 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
     let mut node_config = ShaP2PoolConfig::default();
     std::env::set_var("TARI_NETWORK", "localnet");
     set_network_if_choice_valid(Network::LocalNet)?;
+    let is_seed_node = if diagnostic_mode { false } else { is_seed_node };
 
     let temp_dir_path: PathBuf;
 
@@ -74,7 +77,16 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         node_config.p2p_service.peer_info_publish_interval = Duration::from_secs(1);
         node_config.p2p_service.peer_exchange_interval = Duration::from_secs(1);
         node_config.p2p_service.meta_data_exchange_interval = Duration::from_secs(1);
-        node_config.network_silence_delay = 0;
+        node_config.p2p_service.diagnostic_mode = diagnostic_mode;
+        if diagnostic_mode {
+            node_config.p2p_service.randomx_enabled = false;
+            node_config.p2p_service.sha3x_enabled = false;
+            node_config.network_silence_delay = u64::from(u16::MAX);
+        } else {
+            node_config.p2p_service.randomx_enabled = true;
+            node_config.p2p_service.sha3x_enabled = true;
+            node_config.network_silence_delay = 0;
+        }
         // Each spawned p2pool node will use different ports
         node_config.p2p_port = get_port(18000..18499, Duration::from_secs(20)).ok_or("p2p_port no free port")?;
         node_config.grpc_port = get_port(18500..18999, Duration::from_secs(20)).ok_or("grpc_port no free port")?;
@@ -170,14 +182,18 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         http_server_disabled: !node_config.http_server.enabled,
         user_agent: None,
         peer_publish_interval: Some(node_config.p2p_service.peer_info_publish_interval.as_secs()),
-        debug_print_chain: true,
+        debug_print_chain: false,
+        diagnostic_mode,
         max_connections: None,
-        randomx_disabled: false,
-        sha3x_disabled: false,
+        randomx_disabled: !node_config.p2p_service.randomx_enabled,
+        sha3x_disabled: !node_config.p2p_service.sha3x_enabled,
         block_time: Some(1),
         share_window: Some(100),
         export_libp2p_info: Some(temp_dir_path.join(LIBP2P_INFO_FILE).clone()),
-        network_silence_delay: Some(0),
+        network_silence_delay: {
+            let bytes = node_config.network_silence_delay.to_le_bytes();
+            Some(u16::from_le_bytes([bytes[0], bytes[1]]))
+        },
         minimum_sha3_target_difficulty: Some(Difficulty::min().as_u64()),
         minimum_randomx_target_difficulty: Some(Difficulty::min().as_u64()),
     };
@@ -204,6 +220,7 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         name: p2pool_name.clone(),
         temp_dir_path: temp_dir_path.clone(),
         is_seed_node,
+        diagnostic_mode,
         config: node_config.clone(),
         node_id: libp2p_info.peer_id,
         squad: libp2p_info.squad,
@@ -277,6 +294,7 @@ pub async fn restart_node(world: &mut TariWorld, p2pool_name: String) -> TestRes
 
     let p2pool_process = world.get_p2pool_node(&p2pool_name)?;
     let is_seed_node = p2pool_process.is_seed_node;
+    let diagnostic_mode = p2pool_process.diagnostic_mode;
     let name = p2pool_process.name.clone();
     let squad = p2pool_process.squad.clone();
     let connected_base_node = p2pool_process.connected_base_node.clone();
@@ -284,6 +302,7 @@ pub async fn restart_node(world: &mut TariWorld, p2pool_name: String) -> TestRes
     spawn_p2pool_node_and_wait_for_start(
         world,
         is_seed_node,
+        diagnostic_mode,
         name.clone(),
         squad.clone(),
         connected_base_node.clone(),
@@ -377,6 +396,10 @@ pub fn to_args_command_line(args: StartArgs) -> Vec<String> {
 
     if args.debug_print_chain {
         args_vec.push("--debug-print-chain".to_string());
+    }
+
+    if args.diagnostic_mode {
+        args_vec.push("--diagnostic-mode".to_string());
     }
 
     if let Some(max_connections) = args.max_connections {

--- a/integration_tests/src/p2pool_process.rs
+++ b/integration_tests/src/p2pool_process.rs
@@ -467,6 +467,26 @@ pub fn get_p2pool_exe_path() -> PathBuf {
     }
 }
 
+pub async fn verify_diagnostic_file_created(
+    world: &mut TariWorld,
+    p2pool_name: String,
+    seconds: u64,
+) -> TestResult<()> {
+    debug!(target: LOG_TARGET, "verify '{}' creates a diagnostic file", p2pool_name);
+
+    let p2pool_process = world.get_p2pool_node(&p2pool_name)?;
+    let diagnostic_file_path = p2pool_process.temp_dir_path.join("diagnostic_results.json");
+    let start = Instant::now();
+    while !diagnostic_file_path.exists() && start.elapsed() < Duration::from_secs(seconds) {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    if !diagnostic_file_path.exists() {
+        return Err(format!("Diagnostic file not found at: '{}'", diagnostic_file_path.display()).into());
+    }
+
+    Ok(())
+}
+
 pub async fn verify_peer_connected(world: &mut TariWorld, p2pool_name: String, peer_name: String) -> TestResult<()> {
     debug!(target: LOG_TARGET, "verify '{}' is connected to peer '{}'", p2pool_name, peer_name);
     let start = Instant::now();

--- a/integration_tests/src/p2pool_process.rs
+++ b/integration_tests/src/p2pool_process.rs
@@ -159,6 +159,9 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         .filter(|(_, process)| process.is_seed_node && process.squad == squad)
         .map(|(_, value)| format!("/ip4/127.0.0.1/tcp/{}/p2p/{}", value.p2p_port, value.node_id))
         .collect::<Vec<String>>();
+    for seed_peer in &seed_peers {
+        debug!(target: LOG_TARGET, "'{}' has seed peer: '{}'", p2pool_name, seed_peer);
+    }
 
     let args = StartArgs {
         base_dir: Some(temp_dir_path.clone()),
@@ -183,7 +186,8 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         user_agent: None,
         peer_publish_interval: Some(node_config.p2p_service.peer_info_publish_interval.as_secs()),
         debug_print_chain: false,
-        diagnostic_mode,
+        diagnostic_mode: node_config.p2p_service.diagnostic_mode,
+        diagnostic_mode_file_path: None,
         max_connections: None,
         randomx_disabled: !node_config.p2p_service.randomx_enabled,
         sha3x_disabled: !node_config.p2p_service.sha3x_enabled,
@@ -191,6 +195,7 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         share_window: Some(100),
         export_libp2p_info: Some(temp_dir_path.join(LIBP2P_INFO_FILE).clone()),
         network_silence_delay: {
+            // Note: Any value above u16::MAX will be set to u16::MAX
             let bytes = node_config.network_silence_delay.to_le_bytes();
             Some(u16::from_le_bytes([bytes[0], bytes[1]]))
         },
@@ -310,6 +315,7 @@ pub async fn restart_node(world: &mut TariWorld, p2pool_name: String) -> TestRes
     .await
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn to_args_command_line(args: StartArgs) -> Vec<String> {
     let mut args_vec = Vec::new();
 
@@ -400,6 +406,13 @@ pub fn to_args_command_line(args: StartArgs) -> Vec<String> {
 
     if args.diagnostic_mode {
         args_vec.push("--diagnostic-mode".to_string());
+    }
+
+    if args.diagnostic_mode_file_path.is_some() {
+        args_vec.push(format!(
+            "--diagnostic-mode-file-path={}",
+            args.diagnostic_mode_file_path.unwrap().display()
+        ));
     }
 
     if let Some(max_connections) = args.max_connections {

--- a/integration_tests/tests/features/Sync.feature
+++ b/integration_tests/tests/features/Sync.feature
@@ -8,6 +8,7 @@ Feature: Sync p2pool nodes
   Scenario: New node sync with peers on startup
     Given I have a base node BASE_NODE_A
     And I have a p2pool seed node SEED in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool seed node SEED2 in squad DOLPHINS connected to base node BASE_NODE_A
     And I have a p2pool node NODE_A in squad DOLPHINS connected to base node BASE_NODE_A
     And I add 10 blocks to p2pool node NODE_A
     And p2pool node NODE_A stats is at height 10
@@ -110,3 +111,34 @@ Feature: Sync p2pool nodes
     And p2pool node NODE_B1 stats is at height 5
     And p2pool node NODE_B2 stats is at height 5
     Then I wait 1 seconds and stop
+
+@critical
+  Scenario: I run a diagnostic node to learn about the network connections
+    Given I have a base node BASE_NODE_A
+    # We have 3 seed nodes
+    And I have a p2pool seed node SEED_A in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool seed node SEED_B in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool seed node SEED_C in squad DOLPHINS connected to base node BASE_NODE_A
+    # We have 10 normal nodes
+    And I have a p2pool node NODE_A in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_B in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_C in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_D in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_E in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_F in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_G in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_H in squad DOLPHINS connected to base node BASE_NODE_A
+    And I have a p2pool node NODE_I in squad DOLPHINS connected to base node BASE_NODE_A
+    # The network is well connected
+    And p2pool node NODE_A stats shows connected to peer NODE_B
+    And p2pool node NODE_B stats shows connected to peer NODE_C
+    And p2pool node NODE_C stats shows connected to peer NODE_D
+    And p2pool node NODE_D stats shows connected to peer NODE_E
+    And p2pool node NODE_E stats shows connected to peer NODE_F
+    And p2pool node NODE_F stats shows connected to peer NODE_G
+    And p2pool node NODE_G stats shows connected to peer NODE_H
+    And p2pool node NODE_H stats shows connected to peer NODE_I
+    And p2pool node NODE_I stats shows connected to peer NODE_A
+    # We start a diagnostic node to learn about the network
+    And I have a p2pool diagnostic node DIAGNOSTIC in squad DOLPHINS connected to base node BASE_NODE_A
+    Then I wait 120 seconds and stop

--- a/integration_tests/tests/features/Sync.feature
+++ b/integration_tests/tests/features/Sync.feature
@@ -141,4 +141,5 @@ Feature: Sync p2pool nodes
     And p2pool node NODE_I stats shows connected to peer NODE_A
     # We start a diagnostic node to learn about the network
     And I have a p2pool diagnostic node DIAGNOSTIC in squad DOLPHINS connected to base node BASE_NODE_A
-    Then I wait 120 seconds and stop
+    And I wait up to 120 seconds for p2pool diagnostic node DIAGNOSTIC to create a diagnostic file
+    Then I wait 1 seconds and stop

--- a/integration_tests/tests/steps/p2pool_steps.rs
+++ b/integration_tests/tests/steps/p2pool_steps.rs
@@ -117,7 +117,7 @@ async fn restart_p2pool_node(world: &mut TariWorld, p2pool_name: String) {
 
 #[given(expr = "I wait up to {int} seconds for p2pool diagnostic node {} to create a diagnostic file")]
 #[when(expr = "I wait up to {int} seconds for p2pool diagnostic node {} to create a diagnostic file")]
-async fn verify_p2pool_diagnostic_file(world: &mut TariWorld, p2pool_name: String, seconds: u64) {
+async fn verify_p2pool_diagnostic_file(world: &mut TariWorld, seconds: u64, p2pool_name: String) {
     if let Err(err) = verify_diagnostic_file_created(world, p2pool_name, seconds).await {
         let msg = format!("verify_p2pool_diagnostic_file: {}", err);
         error!(target: LOG_TARGET, "{}", msg);

--- a/integration_tests/tests/steps/p2pool_steps.rs
+++ b/integration_tests/tests/steps/p2pool_steps.rs
@@ -4,7 +4,13 @@
 use cucumber::{given, when};
 use integration_tests::{
     miner::{mine_and_submit_tari_blocks, verify_block_height},
-    p2pool_process::{restart_node, shut_down_node, spawn_p2pool_node_and_wait_for_start, verify_peer_connected},
+    p2pool_process::{
+        restart_node,
+        shut_down_node,
+        spawn_p2pool_node_and_wait_for_start,
+        verify_diagnostic_file_created,
+        verify_peer_connected,
+    },
     TariWorld,
 };
 use log::*;
@@ -103,6 +109,17 @@ async fn shut_down_p2pool_node(world: &mut TariWorld, p2pool_name: String) {
 async fn restart_p2pool_node(world: &mut TariWorld, p2pool_name: String) {
     if let Err(err) = restart_node(world, p2pool_name).await {
         let msg = format!("restart_p2pool_node: {}", err);
+        error!(target: LOG_TARGET, "{}", msg);
+        panic!("{}", msg);
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+}
+
+#[given(expr = "I wait up to {int} seconds for p2pool diagnostic node {} to create a diagnostic file")]
+#[when(expr = "I wait up to {int} seconds for p2pool diagnostic node {} to create a diagnostic file")]
+async fn verify_p2pool_diagnostic_file(world: &mut TariWorld, p2pool_name: String, seconds: u64) {
+    if let Err(err) = verify_diagnostic_file_created(world, p2pool_name, seconds).await {
+        let msg = format!("verify_p2pool_diagnostic_file: {}", err);
         error!(target: LOG_TARGET, "{}", msg);
         panic!("{}", msg);
     }

--- a/integration_tests/tests/steps/p2pool_steps.rs
+++ b/integration_tests/tests/steps/p2pool_steps.rs
@@ -15,7 +15,8 @@ pub const LOG_TARGET: &str = "cucumber::p2pool_steps";
 #[given(expr = "I have a p2pool seed node {word} in squad {word} connected to base node {word}")]
 #[when(expr = "I have a p2pool seed node {word} in squad {word} connected to base node {word}")]
 async fn start_p2pool_seed_node(world: &mut TariWorld, p2pool_name: String, squad: String, base_node_name: String) {
-    if let Err(err) = spawn_p2pool_node_and_wait_for_start(world, true, p2pool_name, squad, base_node_name).await {
+    if let Err(err) = spawn_p2pool_node_and_wait_for_start(world, true, false, p2pool_name, squad, base_node_name).await
+    {
         let msg = format!("start_p2pool_seed_node: {}", err);
         error!(target: LOG_TARGET, "{}", msg);
         panic!("{}", msg);
@@ -26,7 +27,26 @@ async fn start_p2pool_seed_node(world: &mut TariWorld, p2pool_name: String, squa
 #[given(expr = "I have a p2pool node {word} in squad {word} connected to base node {word}")]
 #[when(expr = "I have a p2pool node {word} in squad {word} connected to base node {word}")]
 async fn start_p2pool_node(world: &mut TariWorld, p2pool_name: String, squad: String, base_node_name: String) {
-    if let Err(err) = spawn_p2pool_node_and_wait_for_start(world, false, p2pool_name, squad, base_node_name).await {
+    if let Err(err) =
+        spawn_p2pool_node_and_wait_for_start(world, false, false, p2pool_name, squad, base_node_name).await
+    {
+        let msg = format!("start_p2pool_node: {}", err);
+        error!(target: LOG_TARGET, "{}", msg);
+        panic!("{}", msg);
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+}
+
+#[given(expr = "I have a p2pool diagnostic node {word} in squad {word} connected to base node {word}")]
+#[when(expr = "I have a p2pool diagnostic node {word} in squad {word} connected to base node {word}")]
+async fn start_p2pool_diagnostic_node(
+    world: &mut TariWorld,
+    p2pool_name: String,
+    squad: String,
+    base_node_name: String,
+) {
+    if let Err(err) = spawn_p2pool_node_and_wait_for_start(world, false, true, p2pool_name, squad, base_node_name).await
+    {
         let msg = format!("start_p2pool_node: {}", err);
         error!(target: LOG_TARGET, "{}", msg);
         panic!("{}", msg);

--- a/log4rs_detailed.yml
+++ b/log4rs_detailed.yml
@@ -141,6 +141,11 @@ loggers:
      appenders:
        - p2p
      additive: false
+  tari::p2pool::diagnostics_collector:
+     level: debug
+     appenders:
+       - p2p
+     additive: false
   tari::p2pool::message_logging:
      level: debug
      appenders:

--- a/p2pool/src/cli/args.rs
+++ b/p2pool/src/cli/args.rs
@@ -128,6 +128,10 @@ pub struct StartArgs {
     #[arg(long, short, alias = "diag")]
     pub diagnostic_mode: bool,
 
+    /// An optional location for the diagnostic output file, only relevant when diagnostic mode is set.
+    #[arg(long, short, alias = "diag")]
+    pub diagnostic_mode_file_path: Option<PathBuf>,
+
     #[arg(long)]
     pub max_connections: Option<u32>,
 
@@ -253,8 +257,7 @@ pub async fn run_with_cli(command: &Commands, cli_ref: Arc<Cli>, cli_shutdown: S
             commands::handle_generate_identity().await?;
         },
         Commands::ListSquads { args, list_squad_args } => {
-            commands::handle_list_squads(cli_ref.clone(), args, list_squad_args, cli_shutdown.to_signal().clone())
-                .await?;
+            commands::handle_list_squads(cli_ref.clone(), args, list_squad_args, cli_shutdown.clone()).await?;
         },
     }
 

--- a/p2pool/src/cli/args.rs
+++ b/p2pool/src/cli/args.rs
@@ -4,7 +4,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use clap::{Parser, Subcommand};
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 
 use crate::cli::{
     commands,
@@ -124,6 +124,10 @@ pub struct StartArgs {
     #[arg(long)]
     pub debug_print_chain: bool,
 
+    /// If set, basic connectivity statistics about seeds and normal peers will be collected and printed to a csv file.
+    #[arg(long, short, alias = "diag")]
+    pub diagnostic_mode: bool,
+
     #[arg(long)]
     pub max_connections: Option<u32>,
 
@@ -174,6 +178,12 @@ pub enum Commands {
         args: StartArgs,
     },
 
+    /// Starts sha-p2pool node in diagnostic mode.
+    Diagnostics {
+        #[clap(flatten)]
+        args: StartArgs,
+    },
+
     /// Generating new identity.
     GenerateIdentity,
 
@@ -203,6 +213,10 @@ impl Cli {
                 .base_dir
                 .clone()
                 .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/p2pool")),
+            Commands::Diagnostics { args } => args
+                .base_dir
+                .clone()
+                .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/p2pool")),
             Commands::GenerateIdentity => dirs::home_dir().unwrap().join(".tari/p2pool"),
             Commands::ListSquads {
                 args,
@@ -217,7 +231,7 @@ impl Cli {
     /// Handles CLI command.
     /// [`Cli::parse`] must be called (to have all the args and params set properly)
     /// before calling this method.
-    pub async fn handle_command(&self, cli_shutdown: ShutdownSignal) -> anyhow::Result<()> {
+    pub async fn handle_command(&self, cli_shutdown: Shutdown) -> anyhow::Result<()> {
         let cli_ref = Arc::new(self.clone());
 
         run_with_cli(&self.command, cli_ref, cli_shutdown).await?;
@@ -227,16 +241,20 @@ impl Cli {
 }
 
 /// Run with provided CLI command.
-pub async fn run_with_cli(command: &Commands, cli_ref: Arc<Cli>, cli_shutdown: ShutdownSignal) -> anyhow::Result<()> {
+pub async fn run_with_cli(command: &Commands, cli_ref: Arc<Cli>, cli_shutdown: Shutdown) -> anyhow::Result<()> {
     match command {
         Commands::Start { args } => {
             commands::handle_start(cli_ref.clone(), args, cli_shutdown.clone()).await?;
+        },
+        Commands::Diagnostics { args } => {
+            commands::handle_diagnostics(cli_ref.clone(), args, cli_shutdown.clone()).await?;
         },
         Commands::GenerateIdentity => {
             commands::handle_generate_identity().await?;
         },
         Commands::ListSquads { args, list_squad_args } => {
-            commands::handle_list_squads(cli_ref.clone(), args, list_squad_args, cli_shutdown.clone()).await?;
+            commands::handle_list_squads(cli_ref.clone(), args, list_squad_args, cli_shutdown.to_signal().clone())
+                .await?;
         },
     }
 

--- a/p2pool/src/cli/commands/diagnostics.rs
+++ b/p2pool/src/cli/commands/diagnostics.rs
@@ -12,6 +12,12 @@ use crate::cli::{
 
 pub async fn handle_diagnostics(cli: Arc<Cli>, args: &StartArgs, cli_shutdown: Shutdown) -> anyhow::Result<()> {
     let mut args = args.clone();
+    set_diagnostic_mode(&mut args);
+    util::server(cli, &args, cli_shutdown, true).await?.start().await?;
+    Ok(())
+}
+
+pub fn set_diagnostic_mode(args: &mut StartArgs) {
     args.is_seed_peer = false;
     args.http_server_disabled = false;
     args.peer_publish_interval = Some(30);
@@ -20,6 +26,4 @@ pub async fn handle_diagnostics(cli: Arc<Cli>, args: &StartArgs, cli_shutdown: S
     args.randomx_disabled = true;
     args.sha3x_disabled = true;
     args.network_silence_delay = Some(u16::MAX);
-    util::server(cli, &args, cli_shutdown, true).await?.start().await?;
-    Ok(())
 }

--- a/p2pool/src/cli/commands/diagnostics.rs
+++ b/p2pool/src/cli/commands/diagnostics.rs
@@ -1,0 +1,25 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::sync::Arc;
+
+use tari_shutdown::Shutdown;
+
+use crate::cli::{
+    args::{Cli, StartArgs},
+    commands::util,
+};
+
+pub async fn handle_diagnostics(cli: Arc<Cli>, args: &StartArgs, cli_shutdown: Shutdown) -> anyhow::Result<()> {
+    let mut args = args.clone();
+    args.is_seed_peer = false;
+    args.http_server_disabled = false;
+    args.peer_publish_interval = Some(30);
+    args.debug_print_chain = false;
+    args.diagnostic_mode = true;
+    args.randomx_disabled = true;
+    args.sha3x_disabled = true;
+    args.network_silence_delay = Some(u16::MAX);
+    util::server(cli, &args, cli_shutdown, true).await?.start().await?;
+    Ok(())
+}

--- a/p2pool/src/cli/commands/list_squads.rs
+++ b/p2pool/src/cli/commands/list_squads.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 
 use crate::cli::args::{Cli, ListSquadArgs, StartArgs};
 
@@ -11,7 +11,7 @@ pub async fn handle_list_squads(
     _cli: Arc<Cli>,
     _args: &StartArgs,
     _list_squad_args: &ListSquadArgs,
-    _cli_shutdown_signal: ShutdownSignal,
+    _cli_shutdown: Shutdown,
 ) -> anyhow::Result<()> {
     // start server asynchronously
     // let cli_ref = cli.clone();

--- a/p2pool/src/cli/commands/mod.rs
+++ b/p2pool/src/cli/commands/mod.rs
@@ -10,5 +10,8 @@ pub use list_squads::*;
 mod start;
 pub use start::handle_start;
 
+mod diagnostics;
+pub use diagnostics::handle_diagnostics;
+
 mod util;
 pub use util::LibP2pInfo;

--- a/p2pool/src/cli/commands/start.rs
+++ b/p2pool/src/cli/commands/start.rs
@@ -3,17 +3,14 @@
 
 use std::sync::Arc;
 
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 
 use crate::cli::{
     args::{Cli, StartArgs},
     commands::util,
 };
 
-pub async fn handle_start(cli: Arc<Cli>, args: &StartArgs, cli_shutdown_signal: ShutdownSignal) -> anyhow::Result<()> {
-    util::server(cli, args, cli_shutdown_signal, true)
-        .await?
-        .start()
-        .await?;
+pub async fn handle_start(cli: Arc<Cli>, args: &StartArgs, cli_shutdown: Shutdown) -> anyhow::Result<()> {
+    util::server(cli, args, cli_shutdown, true).await?.start().await?;
     Ok(())
 }

--- a/p2pool/src/cli/commands/util.rs
+++ b/p2pool/src/cli/commands/util.rs
@@ -107,7 +107,11 @@ pub async fn server(
         seed_peers.push(default_seed_peer);
     }
     if let Some(cli_seed_peers) = args.seed_peers.clone() {
-        seed_peers.extend(cli_seed_peers.iter().cloned());
+        let cli_seed_peers: Vec<String> = cli_seed_peers
+            .iter()
+            .flat_map(|s| s.split(',').map(|s| s.trim().to_string()).collect::<Vec<_>>())
+            .collect();
+        seed_peers.extend(cli_seed_peers);
     }
     config_builder.with_seed_peers(seed_peers);
 
@@ -155,7 +159,14 @@ pub async fn server(
     config_builder.with_base_node_address(args.base_node_address.clone());
 
     config_builder.with_block_cache_file(env::current_dir()?.join("block_cache"));
+
+    config_builder.with_diagnostic_mode(args.diagnostic_mode);
+    if let Some(path) = &args.diagnostic_mode_file_path {
+        config_builder.with_diagnostic_mode_file_path(path.clone());
+    }
+
     let config = config_builder.build();
+
     let randomx_factory = RandomXFactory::new(1);
     let consensus_manager = ConsensusManager::builder(Network::get_current_or_user_setting_or_default()).build()?;
     let genesis_block_hash = *consensus_manager.get_genesis_block().hash();
@@ -182,12 +193,12 @@ pub async fn server(
 
     let (stats_tx, stats_rx) = tokio::sync::broadcast::channel(1000);
     let stats_broadcast_client = StatsBroadcastClient::new(stats_tx);
-    let stats_collector = StatsCollector::new(shutdown.to_signal().clone(), stats_rx);
+    let stats_collector = StatsCollector::new(shutdown.clone(), stats_rx);
 
     let (diagnostics_collector, diagnostics_broadcast_client, diagnostics_receiver_client) = if args.diagnostic_mode {
         let (diagnostics_tx, diagnostics_rx) = tokio::sync::broadcast::channel(1000);
         let broadcast_client = DiagnosticsBroadcastClient::new(diagnostics_tx);
-        let collector = DiagnosticsCollector::new(shutdown.to_signal().clone(), diagnostics_rx);
+        let collector = DiagnosticsCollector::new(shutdown.clone(), diagnostics_rx);
         let receiver_client = collector.create_receiver_client();
         (Some(collector), Some(broadcast_client), Some(receiver_client))
     } else {

--- a/p2pool/src/cli/commands/util.rs
+++ b/p2pool/src/cli/commands/util.rs
@@ -23,7 +23,7 @@ use tari_core::{
     consensus::ConsensusManager,
     proof_of_work::{randomx_factory::RandomXFactory, PowAlgorithm},
 };
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use tari_utilities::hex::Hex;
 use tokio::sync::RwLock;
 
@@ -31,6 +31,7 @@ use crate::{
     cli::args::{Cli, StartArgs},
     server::{
         self as main_server,
+        diagnostics::{DiagnosticsBroadcastClient, DiagnosticsCollector},
         http::stats_collector::{StatsBroadcastClient, StatsCollector},
         server::Server,
     },
@@ -43,7 +44,7 @@ const LOG_TARGET: &str = "tari::p2pool::server::p2p";
 pub async fn server(
     cli: Arc<Cli>,
     args: &StartArgs,
-    shutdown_signal: ShutdownSignal,
+    shutdown: Shutdown,
     enable_logging: bool,
 ) -> anyhow::Result<Server<InMemoryShareChain>> {
     if enable_logging {
@@ -181,7 +182,17 @@ pub async fn server(
 
     let (stats_tx, stats_rx) = tokio::sync::broadcast::channel(1000);
     let stats_broadcast_client = StatsBroadcastClient::new(stats_tx);
-    let stats_collector = StatsCollector::new(shutdown_signal.clone(), stats_rx);
+    let stats_collector = StatsCollector::new(shutdown.to_signal().clone(), stats_rx);
+
+    let (diagnostics_collector, diagnostics_broadcast_client, diagnostics_receiver_client) = if args.diagnostic_mode {
+        let (diagnostics_tx, diagnostics_rx) = tokio::sync::broadcast::channel(1000);
+        let broadcast_client = DiagnosticsBroadcastClient::new(diagnostics_tx);
+        let collector = DiagnosticsCollector::new(shutdown.to_signal().clone(), diagnostics_rx);
+        let receiver_client = collector.create_receiver_client();
+        (Some(collector), Some(broadcast_client), Some(receiver_client))
+    } else {
+        (None, None, None)
+    };
 
     if let Some(path) = args.export_libp2p_info.clone() {
         let libp2p_info = LibP2pInfo {
@@ -217,7 +228,10 @@ pub async fn server(
         share_chain_random_x,
         stats_collector,
         stats_broadcast_client,
-        shutdown_signal,
+        diagnostics_collector,
+        diagnostics_broadcast_client,
+        diagnostics_receiver_client,
+        shutdown,
         swarm,
         squad,
     )

--- a/p2pool/src/lib.rs
+++ b/p2pool/src/lib.rs
@@ -12,3 +12,7 @@ mod sharechain;
 pub use sharechain::{lmdb_block_storage::LmdbBlockStorage, p2block::P2BlockBuilder, p2chain::P2Chain};
 
 pub const PROFILING_LOG_TARGET: &str = "tari::profiling";
+
+pub fn anyhow_error(msg: &str) -> anyhow::Error {
+    anyhow::Error::new(std::io::Error::new(std::io::ErrorKind::Other, msg))
+}

--- a/p2pool/src/main.rs
+++ b/p2pool/src/main.rs
@@ -58,6 +58,6 @@ async fn main() -> anyhow::Result<()> {
         }
     }));
 
-    Cli::parse().handle_command(Shutdown::new().to_signal()).await?;
+    Cli::parse().handle_command(Shutdown::new()).await?;
     Ok(())
 }

--- a/p2pool/src/server/config.rs
+++ b/p2pool/src/server/config.rs
@@ -232,6 +232,16 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn with_diagnostic_mode_file_path(&mut self, config: PathBuf) -> &mut Self {
+        self.config.p2p_service.diagnostic_mode_file_path = Some(config);
+        self
+    }
+
+    pub fn with_diagnostic_mode(&mut self, config: bool) -> &mut Self {
+        self.config.p2p_service.diagnostic_mode = config;
+        self
+    }
+
     pub fn build(&self) -> Config {
         self.config.clone()
     }

--- a/p2pool/src/server/diagnostics/diagnostics_collector.rs
+++ b/p2pool/src/server/diagnostics/diagnostics_collector.rs
@@ -1,0 +1,389 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::{collections::HashMap, fmt::Debug, time::Duration};
+
+use libp2p::PeerId;
+use log::*;
+use serde::Serialize;
+use tari_shutdown::ShutdownSignal;
+use tari_utilities::epoch_time::EpochTime;
+use tokio::{
+    sync::{broadcast::Receiver, oneshot},
+    time::MissedTickBehavior,
+};
+
+#[derive(Serialize, Clone, Debug)]
+pub struct DiagnosticPeerInfo {
+    pub peer_id: PeerId,
+    pub connected_at: Option<EpochTime>,
+    pub dial_time: Duration,
+    pub requested_peers_at: Option<EpochTime>,
+    pub number_of_peers: Option<u64>,
+    pub response_time: Option<Duration>,
+}
+
+const LOG_TARGET: &str = "tari::p2pool::diagnostics_collector";
+pub struct DiagnosticsCollector {
+    shutdown_signal: ShutdownSignal,
+    broadcast_receiver: tokio::sync::broadcast::Receiver<DiagnosticData>,
+    request_tx: tokio::sync::mpsc::Sender<DiagnosticRequest>,
+    request_rx: tokio::sync::mpsc::Receiver<DiagnosticRequest>,
+    first_data_received: Option<EpochTime>,
+    seed_peer_info: HashMap<String, DiagnosticPeerInfo>,
+    peer_info: HashMap<String, DiagnosticPeerInfo>,
+    relay_peer_info: HashMap<String, DiagnosticPeerInfo>,
+}
+
+impl DiagnosticsCollector {
+    pub(crate) fn new(shutdown_signal: ShutdownSignal, broadcast_receiver: Receiver<DiagnosticData>) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        Self {
+            shutdown_signal,
+            broadcast_receiver,
+            request_rx: rx,
+            request_tx: tx,
+            first_data_received: None,
+            seed_peer_info: HashMap::new(),
+            peer_info: HashMap::new(),
+            relay_peer_info: HashMap::new(),
+        }
+    }
+
+    pub fn create_receiver_client(&self) -> DiagnosticsReceiverClient {
+        DiagnosticsReceiverClient {
+            request_tx: self.request_tx.clone(),
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn handle_diagnostic(&mut self, data: DiagnosticData) {
+        match data {
+            DiagnosticData::NewSeedPeer {
+                peer_id,
+                dial_time,
+                connected,
+                ..
+            } => {
+                self.seed_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                    peer_id,
+                    connected_at: if connected { Some(EpochTime::now()) } else { None },
+                    dial_time,
+                    requested_peers_at: None,
+                    number_of_peers: None,
+                    response_time: None,
+                });
+            },
+            DiagnosticData::SeedPeerRequest { peer_id, .. } => {
+                if let Some(peer) = self.seed_peer_info.get_mut(&peer_id.to_base58()) {
+                    peer.requested_peers_at = Some(EpochTime::now());
+                }
+            },
+            DiagnosticData::NewPeer {
+                peer_id,
+                dial_time,
+                connected,
+                ..
+            } => {
+                self.peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                    peer_id,
+                    connected_at: if connected { Some(EpochTime::now()) } else { None },
+                    dial_time,
+                    requested_peers_at: None,
+                    number_of_peers: None,
+                    response_time: None,
+                });
+            },
+            DiagnosticData::PeerRequest { peer_id, .. } => {
+                if let Some(peer) = self.peer_info.get_mut(&peer_id.to_base58()) {
+                    peer.requested_peers_at = Some(EpochTime::now());
+                }
+            },
+            DiagnosticData::NewRelayPeer {
+                peer_id,
+                dial_time,
+                connected,
+                ..
+            } => {
+                self.relay_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                    peer_id,
+                    connected_at: if connected { Some(EpochTime::now()) } else { None },
+                    dial_time,
+                    requested_peers_at: None,
+                    number_of_peers: None,
+                    response_time: None,
+                });
+            },
+            DiagnosticData::RelayPeerRequest { peer_id, .. } => {
+                if let Some(peer) = self.relay_peer_info.get_mut(&peer_id.to_base58()) {
+                    peer.requested_peers_at = Some(EpochTime::now());
+                }
+            },
+            DiagnosticData::PeerResponse {
+                peer_id,
+                number_of_peers,
+                ..
+            } => {
+                if let Some(peer) = self.peer_info.get_mut(&peer_id.to_base58()) {
+                    peer.number_of_peers = Some(number_of_peers);
+                    peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
+                        EpochTime::now()
+                            .checked_sub(requested_peers_at)
+                            .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
+                    });
+                } else if let Some(peer) = self.seed_peer_info.get_mut(&peer_id.to_base58()) {
+                    peer.number_of_peers = Some(number_of_peers);
+                    peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
+                        EpochTime::now()
+                            .checked_sub(requested_peers_at)
+                            .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
+                    });
+                } else if let Some(peer) = self.relay_peer_info.get_mut(&peer_id.to_base58()) {
+                    peer.number_of_peers = Some(number_of_peers);
+                    peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
+                        EpochTime::now()
+                            .checked_sub(requested_peers_at)
+                            .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
+                    });
+                } else {
+                    // Nothing here
+                }
+            },
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub(crate) async fn run(&mut self) -> Result<(), anyhow::Error> {
+        let mut diagnostics_report_timer = tokio::time::interval(tokio::time::Duration::from_secs(10));
+        diagnostics_report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = self.shutdown_signal.wait() => {
+                    break;
+                },
+                _ = diagnostics_report_timer.tick() => {
+                    info!(
+                        target: LOG_TARGET,
+                        "========= Uptime: {}. Seeds: {}, Peers: {}, Relay peers: {} ==== ",
+                        humantime::format_duration(Duration::from_secs(EpochTime::now().as_u64().checked_sub(
+                            self.first_data_received.unwrap_or(EpochTime::now()).as_u64()
+                        ).unwrap_or_default())),
+                        self.seed_peer_info.len(),
+                        self.peer_info.len(),
+                        self.relay_peer_info.len(),
+                    );
+                },
+                res = self.request_rx.recv() => {
+                    match res {
+                        Some(DiagnosticRequest::GetSeedPeerInfo(tx)) => {
+                            let _unused  = tx.send(self.seed_peer_info.clone())
+                                .inspect_err(|e|
+                                    error!(target: LOG_TARGET, "Error with seed peers diagnostics response: {:?}", e)
+                                );
+                        },
+                        Some(DiagnosticRequest::GetPeerInfo(tx)) => {
+                            let _unused  = tx.send(self.peer_info.clone())
+                                .inspect_err(|e|
+                                    error!(target: LOG_TARGET, "Error with peers diagnostics response: {:?}", e)
+                                );
+                        },
+                        Some(DiagnosticRequest::GetRelayPeerInfo(tx)) => {
+                            let _unused  = tx.send(self.relay_peer_info.clone())
+                                .inspect_err(|e|
+                                    error!(target: LOG_TARGET, "Error with relay peers diagnostics response: {:?}", e)
+                                );
+                        },
+                        None => {
+                            break;
+                        }
+                    }
+                },
+                res = self.broadcast_receiver.recv() => {
+                    match res {
+                        Ok(data) => {
+                            if self.first_data_received.is_none() {
+                                self.first_data_received = Some(data.timestamp());
+                            }
+                            self.handle_diagnostic(data);
+                        },
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "Error receiving diagnostic data: {:?}", e);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum DiagnosticData {
+    NewSeedPeer {
+        peer_id: PeerId,
+        dial_time: Duration,
+        connected: bool,
+        timestamp: EpochTime,
+    },
+    SeedPeerRequest {
+        peer_id: PeerId,
+        timestamp: EpochTime,
+    },
+    NewPeer {
+        peer_id: PeerId,
+        dial_time: Duration,
+        connected: bool,
+        timestamp: EpochTime,
+    },
+    PeerRequest {
+        peer_id: PeerId,
+        timestamp: EpochTime,
+    },
+    NewRelayPeer {
+        peer_id: PeerId,
+        dial_time: Duration,
+        connected: bool,
+        timestamp: EpochTime,
+    },
+    RelayPeerRequest {
+        peer_id: PeerId,
+        timestamp: EpochTime,
+    },
+    PeerResponse {
+        peer_id: PeerId,
+        number_of_peers: u64,
+        timestamp: EpochTime,
+    },
+}
+
+impl DiagnosticData {
+    pub fn timestamp(&self) -> EpochTime {
+        match self {
+            DiagnosticData::NewSeedPeer { timestamp, .. } => *timestamp,
+            DiagnosticData::SeedPeerRequest { timestamp, .. } => *timestamp,
+            DiagnosticData::NewPeer { timestamp, .. } => *timestamp,
+            DiagnosticData::PeerRequest { timestamp, .. } => *timestamp,
+            DiagnosticData::NewRelayPeer { timestamp, .. } => *timestamp,
+            DiagnosticData::RelayPeerRequest { timestamp, .. } => *timestamp,
+            DiagnosticData::PeerResponse { timestamp, .. } => *timestamp,
+        }
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum DiagnosticRequest {
+    GetSeedPeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
+    GetPeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
+    GetRelayPeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DiagnosticsReceiverClient {
+    request_tx: tokio::sync::mpsc::Sender<DiagnosticRequest>,
+}
+
+impl DiagnosticsReceiverClient {
+    pub async fn get_seed_peer_diagnostic_info(&self) -> Result<HashMap<String, DiagnosticPeerInfo>, anyhow::Error> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx.send(DiagnosticRequest::GetSeedPeerInfo(tx)).await?;
+        Ok(rx.await?)
+    }
+
+    pub async fn get_peer_diagnostic_info(&self) -> Result<HashMap<String, DiagnosticPeerInfo>, anyhow::Error> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx.send(DiagnosticRequest::GetPeerInfo(tx)).await?;
+        Ok(rx.await?)
+    }
+
+    pub async fn get_relay_peer_diagnostic_info(&self) -> Result<HashMap<String, DiagnosticPeerInfo>, anyhow::Error> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx.send(DiagnosticRequest::GetRelayPeerInfo(tx)).await?;
+        Ok(rx.await?)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiagnosticsBroadcastClient {
+    tx: tokio::sync::broadcast::Sender<DiagnosticData>,
+}
+
+impl DiagnosticsBroadcastClient {
+    pub fn new(tx: tokio::sync::broadcast::Sender<DiagnosticData>) -> Self {
+        Self { tx }
+    }
+
+    pub fn broadcast(&self, data: DiagnosticData) -> Result<(), anyhow::Error> {
+        let _unused = self
+            .tx
+            .send(data)
+            .inspect_err(|_e| error!(target: LOG_TARGET, "Diagnostics broadcasting data"));
+        Ok(())
+    }
+
+    pub fn send_new_seed_peer(
+        &self,
+        peer_id: PeerId,
+        dial_time: Duration,
+        connected: bool,
+    ) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::NewSeedPeer {
+            peer_id,
+            dial_time,
+            connected,
+            timestamp: EpochTime::now(),
+        })
+    }
+
+    pub fn send_new_seed_peer_request(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::SeedPeerRequest {
+            peer_id,
+            timestamp: EpochTime::now(),
+        })
+    }
+
+    pub fn send_new_peer(&self, peer_id: PeerId, dial_time: Duration, connected: bool) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::NewPeer {
+            peer_id,
+            timestamp: EpochTime::now(),
+            dial_time,
+            connected,
+        })
+    }
+
+    pub fn send_new_peer_request(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::PeerRequest {
+            peer_id,
+            timestamp: EpochTime::now(),
+        })
+    }
+
+    pub fn send_new_relay_peer(
+        &self,
+        peer_id: PeerId,
+        dial_time: Duration,
+        connected: bool,
+    ) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::NewRelayPeer {
+            peer_id,
+            timestamp: EpochTime::now(),
+            dial_time,
+            connected,
+        })
+    }
+
+    pub fn send_new_relay_peer_request(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::RelayPeerRequest {
+            peer_id,
+            timestamp: EpochTime::now(),
+        })
+    }
+
+    pub fn send_peer_response(&self, peer_id: PeerId, number_of_peers: u64) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::PeerResponse {
+            peer_id,
+            number_of_peers,
+            timestamp: EpochTime::now(),
+        })
+    }
+}

--- a/p2pool/src/server/diagnostics/diagnostics_collector.rs
+++ b/p2pool/src/server/diagnostics/diagnostics_collector.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, fmt::Debug, time::Duration};
 use libp2p::PeerId;
 use log::*;
 use serde::Serialize;
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use tari_utilities::epoch_time::EpochTime;
 use tokio::{
     sync::{broadcast::Receiver, oneshot},
@@ -16,36 +16,87 @@ use tokio::{
 #[derive(Serialize, Clone, Debug)]
 pub struct DiagnosticPeerInfo {
     pub peer_id: PeerId,
-    pub connected_at: Option<EpochTime>,
+    #[serde(with = "duration_as_seconds")]
     pub dial_time: Duration,
+    pub dial_succeeded: bool,
+    #[serde(with = "epoch_time_as_rfc3339")]
+    pub connected_at: Option<EpochTime>,
+    #[serde(with = "epoch_time_as_rfc3339")]
     pub requested_peers_at: Option<EpochTime>,
-    pub number_of_peers: Option<u64>,
+    pub number_of_peers: Option<usize>,
+    #[serde(with = "duration_option_as_seconds")]
     pub response_time: Option<Duration>,
+}
+
+mod epoch_time_as_rfc3339 {
+    use chrono::{Local, TimeZone};
+    use serde::Serializer;
+
+    use super::*;
+
+    pub fn serialize<S>(time: &Option<EpochTime>, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        match time {
+            Some(t) => {
+                let dt = Local
+                    .timestamp_opt(i64::try_from(t.as_u64()).unwrap_or_default(), 0)
+                    .single()
+                    .unwrap_or_default();
+                serializer.serialize_some(&dt.to_rfc3339())
+            },
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+mod duration_as_seconds {
+    use std::time::Duration;
+
+    use serde::Serializer;
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        serializer.serialize_some(&(duration.as_secs() as f64 + f64::from(duration.subsec_millis()) * 1e-3))
+    }
+}
+
+mod duration_option_as_seconds {
+    use std::time::Duration;
+
+    use serde::Serializer;
+
+    pub fn serialize<S>(duration: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        match duration {
+            Some(d) => serializer.serialize_some(&(d.as_secs() as f64 + f64::from(d.subsec_millis()) * 1e-3)),
+            None => serializer.serialize_none(),
+        }
+    }
 }
 
 const LOG_TARGET: &str = "tari::p2pool::diagnostics_collector";
 pub struct DiagnosticsCollector {
-    shutdown_signal: ShutdownSignal,
+    shutdown: Shutdown,
     broadcast_receiver: tokio::sync::broadcast::Receiver<DiagnosticData>,
     request_tx: tokio::sync::mpsc::Sender<DiagnosticRequest>,
     request_rx: tokio::sync::mpsc::Receiver<DiagnosticRequest>,
     first_data_received: Option<EpochTime>,
     seed_peer_info: HashMap<String, DiagnosticPeerInfo>,
-    peer_info: HashMap<String, DiagnosticPeerInfo>,
+    private_peer_info: HashMap<String, DiagnosticPeerInfo>,
     relay_peer_info: HashMap<String, DiagnosticPeerInfo>,
 }
 
 impl DiagnosticsCollector {
-    pub(crate) fn new(shutdown_signal: ShutdownSignal, broadcast_receiver: Receiver<DiagnosticData>) -> Self {
+    pub(crate) fn new(shutdown: Shutdown, broadcast_receiver: Receiver<DiagnosticData>) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
         Self {
-            shutdown_signal,
+            shutdown,
             broadcast_receiver,
             request_rx: rx,
             request_tx: tx,
             first_data_received: None,
             seed_peer_info: HashMap::new(),
-            peer_info: HashMap::new(),
+            private_peer_info: HashMap::new(),
             relay_peer_info: HashMap::new(),
         }
     }
@@ -58,65 +109,78 @@ impl DiagnosticsCollector {
 
     #[allow(clippy::too_many_lines)]
     fn handle_diagnostic(&mut self, data: DiagnosticData) {
+        debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
         match data {
             DiagnosticData::NewSeedPeer {
                 peer_id,
                 dial_time,
-                connected,
+                dial_succeeded,
                 ..
             } => {
                 self.seed_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
                     peer_id,
-                    connected_at: if connected { Some(EpochTime::now()) } else { None },
                     dial_time,
+                    dial_succeeded,
+                    connected_at: None,
                     requested_peers_at: None,
                     number_of_peers: None,
                     response_time: None,
                 });
             },
-            DiagnosticData::SeedPeerRequest { peer_id, .. } => {
-                if let Some(peer) = self.seed_peer_info.get_mut(&peer_id.to_base58()) {
-                    peer.requested_peers_at = Some(EpochTime::now());
-                }
-            },
-            DiagnosticData::NewPeer {
+            DiagnosticData::NewPrivatePeer {
                 peer_id,
                 dial_time,
-                connected,
+                dial_succeeded,
                 ..
             } => {
-                self.peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                self.private_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
                     peer_id,
-                    connected_at: if connected { Some(EpochTime::now()) } else { None },
                     dial_time,
+                    dial_succeeded,
+                    connected_at: None,
+                    requested_peers_at: None,
+                    number_of_peers: None,
+                    response_time: None,
+                });
+            },
+            DiagnosticData::NewRelayPeer {
+                peer_id,
+                dial_time,
+                dial_succeeded,
+                ..
+            } => {
+                self.relay_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                    peer_id,
+                    dial_time,
+                    dial_succeeded,
+                    connected_at: None,
                     requested_peers_at: None,
                     number_of_peers: None,
                     response_time: None,
                 });
             },
             DiagnosticData::PeerRequest { peer_id, .. } => {
-                if let Some(peer) = self.peer_info.get_mut(&peer_id.to_base58()) {
-                    peer.requested_peers_at = Some(EpochTime::now());
+                let existing_peer = self
+                    .private_peer_info
+                    .get_mut(&peer_id.to_base58())
+                    .or_else(|| self.seed_peer_info.get_mut(&peer_id.to_base58()))
+                    .or_else(|| self.relay_peer_info.get_mut(&peer_id.to_base58()));
+                if let Some(peer) = existing_peer {
+                    if peer.requested_peers_at.is_none() {
+                        peer.requested_peers_at = Some(EpochTime::now());
+                    }
                 }
             },
-            DiagnosticData::NewRelayPeer {
-                peer_id,
-                dial_time,
-                connected,
-                ..
-            } => {
-                self.relay_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
-                    peer_id,
-                    connected_at: if connected { Some(EpochTime::now()) } else { None },
-                    dial_time,
-                    requested_peers_at: None,
-                    number_of_peers: None,
-                    response_time: None,
-                });
-            },
-            DiagnosticData::RelayPeerRequest { peer_id, .. } => {
-                if let Some(peer) = self.relay_peer_info.get_mut(&peer_id.to_base58()) {
-                    peer.requested_peers_at = Some(EpochTime::now());
+            DiagnosticData::PeerConnected { peer_id, .. } => {
+                let existing_peer = self
+                    .private_peer_info
+                    .get_mut(&peer_id.to_base58())
+                    .or_else(|| self.seed_peer_info.get_mut(&peer_id.to_base58()))
+                    .or_else(|| self.relay_peer_info.get_mut(&peer_id.to_base58()));
+                if let Some(peer) = existing_peer {
+                    if peer.connected_at.is_none() {
+                        peer.connected_at = Some(EpochTime::now());
+                    }
                 }
             },
             DiagnosticData::PeerResponse {
@@ -124,29 +188,29 @@ impl DiagnosticsCollector {
                 number_of_peers,
                 ..
             } => {
-                if let Some(peer) = self.peer_info.get_mut(&peer_id.to_base58()) {
-                    peer.number_of_peers = Some(number_of_peers);
-                    peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
-                        EpochTime::now()
-                            .checked_sub(requested_peers_at)
-                            .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
-                    });
-                } else if let Some(peer) = self.seed_peer_info.get_mut(&peer_id.to_base58()) {
-                    peer.number_of_peers = Some(number_of_peers);
-                    peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
-                        EpochTime::now()
-                            .checked_sub(requested_peers_at)
-                            .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
-                    });
-                } else if let Some(peer) = self.relay_peer_info.get_mut(&peer_id.to_base58()) {
-                    peer.number_of_peers = Some(number_of_peers);
-                    peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
-                        EpochTime::now()
-                            .checked_sub(requested_peers_at)
-                            .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
-                    });
-                } else {
-                    // Nothing here
+                let existing_peer = self
+                    .private_peer_info
+                    .get_mut(&peer_id.to_base58())
+                    .or_else(|| self.seed_peer_info.get_mut(&peer_id.to_base58()))
+                    .or_else(|| self.relay_peer_info.get_mut(&peer_id.to_base58()));
+                if let Some(peer) = existing_peer {
+                    if let Some(number) = peer.number_of_peers {
+                        if number_of_peers > number {
+                            peer.number_of_peers = Some(number_of_peers);
+                            peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
+                                EpochTime::now()
+                                    .checked_sub(requested_peers_at)
+                                    .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
+                            });
+                        }
+                    } else {
+                        peer.number_of_peers = Some(number_of_peers);
+                        peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
+                            EpochTime::now()
+                                .checked_sub(requested_peers_at)
+                                .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
+                        });
+                    }
                 }
             },
         }
@@ -157,9 +221,10 @@ impl DiagnosticsCollector {
         let mut diagnostics_report_timer = tokio::time::interval(tokio::time::Duration::from_secs(10));
         diagnostics_report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+        let mut shutdown_signal = self.shutdown.to_signal();
         loop {
             tokio::select! {
-                _ = self.shutdown_signal.wait() => {
+                _ = shutdown_signal.wait() => {
                     break;
                 },
                 _ = diagnostics_report_timer.tick() => {
@@ -170,7 +235,7 @@ impl DiagnosticsCollector {
                             self.first_data_received.unwrap_or(EpochTime::now()).as_u64()
                         ).unwrap_or_default())),
                         self.seed_peer_info.len(),
-                        self.peer_info.len(),
+                        self.private_peer_info.len(),
                         self.relay_peer_info.len(),
                     );
                 },
@@ -179,21 +244,32 @@ impl DiagnosticsCollector {
                         Some(DiagnosticRequest::GetSeedPeerInfo(tx)) => {
                             let _unused  = tx.send(self.seed_peer_info.clone())
                                 .inspect_err(|e|
-                                    error!(target: LOG_TARGET, "Error with seed peers diagnostics response: {:?}", e)
+                                    error!(target: LOG_TARGET, "Error seed peers diagnostics response: {:?}", e)
                                 );
                         },
-                        Some(DiagnosticRequest::GetPeerInfo(tx)) => {
-                            let _unused  = tx.send(self.peer_info.clone())
+                        Some(DiagnosticRequest::GetPrivatePeerInfo(tx)) => {
+                            let _unused  = tx.send(self.private_peer_info.clone())
                                 .inspect_err(|e|
-                                    error!(target: LOG_TARGET, "Error with peers diagnostics response: {:?}", e)
+                                    error!(target: LOG_TARGET, "Error peers diagnostics response: {:?}", e)
                                 );
                         },
                         Some(DiagnosticRequest::GetRelayPeerInfo(tx)) => {
                             let _unused  = tx.send(self.relay_peer_info.clone())
                                 .inspect_err(|e|
-                                    error!(target: LOG_TARGET, "Error with relay peers diagnostics response: {:?}", e)
+                                    error!(target: LOG_TARGET, "Error relay peers diagnostics response: {:?}", e)
                                 );
                         },
+                        Some(DiagnosticRequest::GetConnectedPeers(tx)) => {
+                            let connected_peers: Vec<_> = self.seed_peer_info.values()
+                                .chain(self.private_peer_info.values())
+                                .chain(self.relay_peer_info.values())
+                                .filter_map(|d| d.connected_at.map(|_| d.peer_id))
+                                .collect();
+                            let _unused = tx.send(connected_peers)
+                                .inspect_err(|e|
+                                    error!(target: LOG_TARGET, "Error connected peers diagnostics response: {:?}", e)
+                                );
+                        }
                         None => {
                             break;
                         }
@@ -218,41 +294,37 @@ impl DiagnosticsCollector {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum DiagnosticData {
     NewSeedPeer {
         peer_id: PeerId,
         dial_time: Duration,
-        connected: bool,
+        dial_succeeded: bool,
         timestamp: EpochTime,
     },
-    SeedPeerRequest {
-        peer_id: PeerId,
-        timestamp: EpochTime,
-    },
-    NewPeer {
+    NewPrivatePeer {
         peer_id: PeerId,
         dial_time: Duration,
-        connected: bool,
+        dial_succeeded: bool,
+        timestamp: EpochTime,
+    },
+    NewRelayPeer {
+        peer_id: PeerId,
+        dial_time: Duration,
+        dial_succeeded: bool,
         timestamp: EpochTime,
     },
     PeerRequest {
         peer_id: PeerId,
         timestamp: EpochTime,
     },
-    NewRelayPeer {
-        peer_id: PeerId,
-        dial_time: Duration,
-        connected: bool,
-        timestamp: EpochTime,
-    },
-    RelayPeerRequest {
-        peer_id: PeerId,
-        timestamp: EpochTime,
-    },
     PeerResponse {
         peer_id: PeerId,
-        number_of_peers: u64,
+        number_of_peers: usize,
+        timestamp: EpochTime,
+    },
+    PeerConnected {
+        peer_id: PeerId,
         timestamp: EpochTime,
     },
 }
@@ -261,12 +333,11 @@ impl DiagnosticData {
     pub fn timestamp(&self) -> EpochTime {
         match self {
             DiagnosticData::NewSeedPeer { timestamp, .. } => *timestamp,
-            DiagnosticData::SeedPeerRequest { timestamp, .. } => *timestamp,
-            DiagnosticData::NewPeer { timestamp, .. } => *timestamp,
-            DiagnosticData::PeerRequest { timestamp, .. } => *timestamp,
+            DiagnosticData::NewPrivatePeer { timestamp, .. } => *timestamp,
             DiagnosticData::NewRelayPeer { timestamp, .. } => *timestamp,
-            DiagnosticData::RelayPeerRequest { timestamp, .. } => *timestamp,
+            DiagnosticData::PeerRequest { timestamp, .. } => *timestamp,
             DiagnosticData::PeerResponse { timestamp, .. } => *timestamp,
+            DiagnosticData::PeerConnected { timestamp, .. } => *timestamp,
         }
     }
 }
@@ -274,8 +345,9 @@ impl DiagnosticData {
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum DiagnosticRequest {
     GetSeedPeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
-    GetPeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
+    GetPrivatePeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
     GetRelayPeerInfo(tokio::sync::oneshot::Sender<HashMap<String, DiagnosticPeerInfo>>),
+    GetConnectedPeers(tokio::sync::oneshot::Sender<Vec<PeerId>>),
 }
 
 #[derive(Debug, Clone)]
@@ -290,15 +362,21 @@ impl DiagnosticsReceiverClient {
         Ok(rx.await?)
     }
 
-    pub async fn get_peer_diagnostic_info(&self) -> Result<HashMap<String, DiagnosticPeerInfo>, anyhow::Error> {
+    pub async fn get_private_peer_diagnostic_info(&self) -> Result<HashMap<String, DiagnosticPeerInfo>, anyhow::Error> {
         let (tx, rx) = oneshot::channel();
-        self.request_tx.send(DiagnosticRequest::GetPeerInfo(tx)).await?;
+        self.request_tx.send(DiagnosticRequest::GetPrivatePeerInfo(tx)).await?;
         Ok(rx.await?)
     }
 
     pub async fn get_relay_peer_diagnostic_info(&self) -> Result<HashMap<String, DiagnosticPeerInfo>, anyhow::Error> {
         let (tx, rx) = oneshot::channel();
         self.request_tx.send(DiagnosticRequest::GetRelayPeerInfo(tx)).await?;
+        Ok(rx.await?)
+    }
+
+    pub async fn get_connected_peers(&self) -> Result<Vec<PeerId>, anyhow::Error> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx.send(DiagnosticRequest::GetConnectedPeers(tx)).await?;
         Ok(rx.await?)
     }
 }
@@ -325,29 +403,41 @@ impl DiagnosticsBroadcastClient {
         &self,
         peer_id: PeerId,
         dial_time: Duration,
-        connected: bool,
+        dial_succeeded: bool,
     ) -> Result<(), anyhow::Error> {
         self.broadcast(DiagnosticData::NewSeedPeer {
             peer_id,
             dial_time,
-            connected,
+            dial_succeeded,
             timestamp: EpochTime::now(),
         })
     }
 
-    pub fn send_new_seed_peer_request(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::SeedPeerRequest {
-            peer_id,
-            timestamp: EpochTime::now(),
-        })
-    }
-
-    pub fn send_new_peer(&self, peer_id: PeerId, dial_time: Duration, connected: bool) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::NewPeer {
+    pub fn send_new_private_peer(
+        &self,
+        peer_id: PeerId,
+        dial_time: Duration,
+        dial_succeeded: bool,
+    ) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::NewPrivatePeer {
             peer_id,
             timestamp: EpochTime::now(),
             dial_time,
-            connected,
+            dial_succeeded,
+        })
+    }
+
+    pub fn send_new_relay_peer(
+        &self,
+        peer_id: PeerId,
+        dial_time: Duration,
+        dial_succeeded: bool,
+    ) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::NewRelayPeer {
+            peer_id,
+            timestamp: EpochTime::now(),
+            dial_time,
+            dial_succeeded,
         })
     }
 
@@ -358,31 +448,17 @@ impl DiagnosticsBroadcastClient {
         })
     }
 
-    pub fn send_new_relay_peer(
-        &self,
-        peer_id: PeerId,
-        dial_time: Duration,
-        connected: bool,
-    ) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::NewRelayPeer {
-            peer_id,
-            timestamp: EpochTime::now(),
-            dial_time,
-            connected,
-        })
-    }
-
-    pub fn send_new_relay_peer_request(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::RelayPeerRequest {
-            peer_id,
-            timestamp: EpochTime::now(),
-        })
-    }
-
-    pub fn send_peer_response(&self, peer_id: PeerId, number_of_peers: u64) -> Result<(), anyhow::Error> {
+    pub fn send_peer_response(&self, peer_id: PeerId, number_of_peers: usize) -> Result<(), anyhow::Error> {
         self.broadcast(DiagnosticData::PeerResponse {
             peer_id,
             number_of_peers,
+            timestamp: EpochTime::now(),
+        })
+    }
+
+    pub fn send_peer_connected(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
+        self.broadcast(DiagnosticData::PeerConnected {
+            peer_id,
             timestamp: EpochTime::now(),
         })
     }

--- a/p2pool/src/server/diagnostics/mod.rs
+++ b/p2pool/src/server/diagnostics/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+mod diagnostics_collector;
+pub use diagnostics_collector::*;

--- a/p2pool/src/server/grpc/base_node.rs
+++ b/p2pool/src/server/grpc/base_node.rs
@@ -59,7 +59,7 @@ use minotari_app_grpc::{
         ValueAtHeightResponse,
     },
 };
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use tokio::sync::RwLock;
 use tonic::{transport::Channel, Request, Response, Status, Streaming};
 
@@ -178,11 +178,9 @@ pub struct TariBaseNodeGrpc {
 }
 
 impl TariBaseNodeGrpc {
-    pub async fn new(base_node_address: String, shutdown_signal: ShutdownSignal) -> Result<Self, Error> {
+    pub async fn new(base_node_address: String, shutdown: Shutdown) -> Result<Self, Error> {
         Ok(Self {
-            client: Arc::new(RwLock::new(
-                util::connect_base_node(base_node_address, shutdown_signal).await?,
-            )),
+            client: Arc::new(RwLock::new(util::connect_base_node(base_node_address, shutdown).await?)),
         })
     }
 }

--- a/p2pool/src/server/grpc/util.rs
+++ b/p2pool/src/server/grpc/util.rs
@@ -6,7 +6,7 @@ use std::{num::TryFromIntError, time::Duration};
 use log::error;
 use minotari_app_grpc::tari_rpc::base_node_client::BaseNodeClient;
 use minotari_node_grpc_client::BaseNodeGrpcClient;
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use tokio::select;
 use tonic::transport::Channel;
 
@@ -15,7 +15,7 @@ use crate::server::grpc::error::{Error, TonicError};
 /// Utility function to connect to a Base node and try infinitely when it fails until gets connected.
 pub async fn connect_base_node(
     base_node_address: String,
-    shutdown_signal: ShutdownSignal,
+    shutdown: Shutdown,
 ) -> Result<BaseNodeClient<Channel>, Error> {
     let client_result = BaseNodeGrpcClient::connect(base_node_address.clone())
         .await
@@ -26,6 +26,7 @@ pub async fn connect_base_node(
             error!("[Retry] Failed to connect to Tari base node: {:?}", error.to_string());
             let mut client = None;
             let mut retry_interval = tokio::time::interval(Duration::from_secs(5));
+            let shutdown_signal = shutdown.to_signal();
             tokio::pin!(shutdown_signal);
             while client.is_none() {
                 select! {

--- a/p2pool/src/server/http/server.rs
+++ b/p2pool/src/server/http/server.rs
@@ -3,7 +3,7 @@
 
 use axum::{routing::get, Router};
 use log::info;
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use thiserror::Error;
 use tokio::{io, sync::mpsc::Sender};
 
@@ -40,7 +40,7 @@ pub struct HttpServer {
     stats_client: StatsClient,
     port: u16,
     p2p_service_client: Sender<P2pServiceQuery>,
-    shutdown_signal: ShutdownSignal,
+    shutdown: Shutdown,
 }
 
 #[derive(Clone)]
@@ -54,13 +54,13 @@ impl HttpServer {
         stats_client: StatsClient,
         port: u16,
         p2p_service_client: Sender<P2pServiceQuery>,
-        shutdown_signal: ShutdownSignal,
+        shutdown: Shutdown,
     ) -> Self {
         Self {
             stats_client,
             port,
             p2p_service_client,
-            shutdown_signal,
+            shutdown,
         }
     }
 
@@ -87,8 +87,9 @@ impl HttpServer {
             .await
             .map_err(Error::IO)?;
         info!(target: LOG_TARGET, "Starting Stats HTTP server at http://127.0.0.1:{}", self.port);
+        let shutdown_signal = self.shutdown.to_signal();
         axum::serve(listener, router)
-            .with_graceful_shutdown(self.shutdown_signal.clone())
+            .with_graceful_shutdown(shutdown_signal)
             .await
             .map_err(Error::IO)?;
         info!(target: LOG_TARGET, "Stats HTTP server stopped!");

--- a/p2pool/src/server/http/stats_collector.rs
+++ b/p2pool/src/server/http/stats_collector.rs
@@ -8,7 +8,7 @@ use libp2p::PeerId;
 use log::{debug, error, info};
 use serde::Serialize;
 use tari_core::proof_of_work::{Difficulty, PowAlgorithm};
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use tari_utilities::epoch_time::EpochTime;
 use tokio::{
     sync::{broadcast::Receiver, oneshot},
@@ -17,7 +17,7 @@ use tokio::{
 
 const LOG_TARGET: &str = "tari::p2pool::server::stats_collector";
 pub(crate) struct StatsCollector {
-    shutdown_signal: ShutdownSignal,
+    shutdown: Shutdown,
     stats_broadcast_receiver: tokio::sync::broadcast::Receiver<StatData>,
     request_tx: tokio::sync::mpsc::Sender<StatsRequest>,
     request_rx: tokio::sync::mpsc::Receiver<StatsRequest>,
@@ -50,10 +50,10 @@ pub(crate) struct StatsCollector {
 }
 
 impl StatsCollector {
-    pub(crate) fn new(shutdown_signal: ShutdownSignal, stats_broadcast_receiver: Receiver<StatData>) -> Self {
+    pub(crate) fn new(shutdown: Shutdown, stats_broadcast_receiver: Receiver<StatData>) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
         Self {
-            shutdown_signal,
+            shutdown,
             stats_broadcast_receiver,
             request_rx: rx,
             request_tx: tx,
@@ -191,9 +191,10 @@ impl StatsCollector {
         let mut stats_report_timer = tokio::time::interval(tokio::time::Duration::from_secs(10));
         stats_report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+        let mut shutdown_signal = self.shutdown.to_signal();
         loop {
             tokio::select! {
-                _ = self.shutdown_signal.wait() => {
+                _ = shutdown_signal.wait() => {
                     break;
                 },
                 _ = stats_report_timer.tick() => {

--- a/p2pool/src/server/mod.rs
+++ b/p2pool/src/server/mod.rs
@@ -1,12 +1,13 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-pub use config::*;
-
 mod config;
+pub use config::*;
 
 #[allow(clippy::module_inception)]
 pub mod server;
+
+pub mod diagnostics;
 
 pub mod grpc;
 pub mod http;

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -3199,23 +3199,23 @@ where S: ShareChain
                             let summary = ("summary", json!(
                                 {
                                     "summary": {
-                                        "1. Connect to DNS seeds             :":
+                                        "1. Connect to DNS seeds             _":
                                             seeds_data.iter().any(|peer| peer.dial_succeeded),
-                                        "2. Download peers from DNS seeds    :":
+                                        "2. Download peers from DNS seeds    _":
                                             seeds_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
-                                        "3. Number of DNS seeds responded    :":
+                                        "3. Number of DNS seeds responded    _":
                                             seeds_data.iter().filter(|peer| peer.response_time.is_some()).count(),
-                                        "4. Connect to relay peers           :":
+                                        "4. Connect to relay peers           _":
                                             relays_data.iter().any(|peer| peer.dial_succeeded),
-                                        "5. Download peers from relay peers  :":
+                                        "5. Download peers from relay peers  _":
                                             relays_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
-                                        "6. Number of relay peers responded  :":
+                                        "6. Number of relay peers responded  _":
                                             relays_data.iter().filter(|peer| peer.response_time.is_some()).count(),
-                                        "7. Connect to private peers         :":
+                                        "7. Connect to private peers         _":
                                             private_peers_data.iter().any(|peer| peer.dial_succeeded),
-                                        "8. Download peers from private peers:":
+                                        "8. Download peers from private peers_":
                                             private_peers_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
-                                        "9. Number of private peers responded:":
+                                        "9. Number of private peers responded_":
                                             private_peers_data.iter().filter(|peer| peer.response_time.is_some()).count(),
                                     }
                                 })

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::HashMap,
     fs,
+    fs::File,
     io::Write,
     net::IpAddr,
     num::NonZeroUsize,
@@ -40,10 +41,11 @@ use log::{debug, error, info, trace, warn};
 use lru::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tari_common::configuration::Network;
 use tari_common_types::types::FixedHash;
 use tari_core::proof_of_work::PowAlgorithm;
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::Shutdown;
 use tari_utilities::{epoch_time::EpochTime, hex::Hex};
 use tokio::{
     select,
@@ -60,8 +62,10 @@ use tokio::{
 
 use super::messages::{CatchUpSyncRequest, CatchUpSyncResponse, MetaDataRequest, MetaDataResponse, NotifyNewTipBlock};
 use crate::{
+    anyhow_error,
     server::{
         config,
+        diagnostics::{DiagnosticPeerInfo, DiagnosticsBroadcastClient, DiagnosticsReceiverClient},
         http::stats_collector::StatsBroadcastClient,
         p2p::{
             client::ServiceClient,
@@ -73,7 +77,7 @@ use crate::{
                 SyncMissingBlocksRequest,
                 SyncMissingBlocksResponse,
             },
-            peer_store::{AddPeerStatus, PeerStore},
+            peer_store::{AddPeerStatus, PeerStore, PeerStoreRecord},
             relay_store::RelayStore,
         },
         PROTOCOL_VERSION,
@@ -135,6 +139,7 @@ pub struct Config {
     pub num_concurrent_syncs: usize,
     pub num_sync_tips_to_keep: usize,
     pub max_missing_blocks_sync_depth: usize,
+    pub diagnostic_mode: bool,
 }
 
 impl Default for Config {
@@ -164,6 +169,7 @@ impl Default for Config {
             num_concurrent_syncs: 1,
             num_sync_tips_to_keep: 10,
             max_missing_blocks_sync_depth: 8,
+            diagnostic_mode: false,
         }
     }
 }
@@ -277,7 +283,7 @@ where S: ShareChain
     share_chain_random_x: Arc<S>,
     network_peer_store: Arc<RwLock<PeerStore>>,
     config: Config,
-    shutdown_signal: ShutdownSignal,
+    shutdown: Shutdown,
     // share_chain_sync_tx: broadcast::Sender<LocalShareChainSyncRequest>,
     query_tx: mpsc::Sender<P2pServiceQuery>,
     query_rx: mpsc::Receiver<P2pServiceQuery>,
@@ -292,6 +298,8 @@ where S: ShareChain
     are_we_synced_with_randomx_p2pool: Arc<AtomicBool>,
     are_we_synced_with_sha3x_p2pool: Arc<AtomicBool>,
     stats_broadcast_client: StatsBroadcastClient,
+    diagnostics_broadcast_client: Option<DiagnosticsBroadcastClient>,
+    diagnostics_receiver_client: Option<DiagnosticsReceiverClient>,
     randomx_sync_semaphore: Arc<Semaphore>,
     sha3x_sync_semaphore: Arc<Semaphore>,
     randomx_last_sync_requested_block: Option<(u64, FixedHash)>,
@@ -312,10 +320,12 @@ where S: ShareChain
         config: &config::Config,
         share_chain_sha3x: Arc<S>,
         share_chain_random_x: Arc<S>,
-        shutdown_signal: ShutdownSignal,
+        shutdown: Shutdown,
         are_we_synced_with_randomx_p2pool: Arc<AtomicBool>,
         are_we_synced_with_sha3x_p2pool: Arc<AtomicBool>,
         stats_broadcast_client: StatsBroadcastClient,
+        diagnostics_broadcast_client: Option<DiagnosticsBroadcastClient>,
+        diagnostics_receiver_client: Option<DiagnosticsReceiverClient>,
         share_window: u64,
         swarm: Swarm<ServerNetworkBehaviour>,
         squad: String,
@@ -352,7 +362,7 @@ where S: ShareChain
             share_chain_random_x,
             network_peer_store: Arc::new(RwLock::new(network_peer_store)),
             config: config.p2p_service.clone(),
-            shutdown_signal,
+            shutdown,
             client_broadcast_block_tx: broadcast_block_tx,
             client_broadcast_block_rx: broadcast_block_rx,
             inner_request_tx,
@@ -363,6 +373,8 @@ where S: ShareChain
             are_we_synced_with_randomx_p2pool,
             are_we_synced_with_sha3x_p2pool,
             stats_broadcast_client,
+            diagnostics_broadcast_client,
+            diagnostics_receiver_client,
             randomx_sync_semaphore: Arc::new(Semaphore::new(config.p2p_service.num_concurrent_syncs)),
             sha3x_sync_semaphore: Arc::new(Semaphore::new(config.p2p_service.num_concurrent_syncs)),
             randomx_last_sync_requested_block: None,
@@ -506,7 +518,9 @@ where S: ShareChain
         if self.config.is_seed_peer {
             return;
         }
-        self.subscribe(BLOCK_NOTIFY_TOPIC, true);
+        if !self.config.diagnostic_mode {
+            self.subscribe(BLOCK_NOTIFY_TOPIC, true);
+        }
     }
 
     /// Main method to handle any message comes from gossipsub.
@@ -1089,6 +1103,11 @@ where S: ShareChain
                     );
                     let _ = self.swarm.disconnect_peer_id(peer_id);
                     return;
+                }
+
+                // Update peer stats
+                if let Some(client) = &self.diagnostics_broadcast_client {
+                    let _unused = client.send_peer_response(peer_id, num_peers_added);
                 }
 
                 // if we are a seed peer, end here
@@ -2485,7 +2504,7 @@ where S: ShareChain
         };
         debug_chain_graph.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        let shutdown_signal = self.shutdown_signal.clone();
+        let shutdown_signal = self.shutdown.to_signal().clone();
         tokio::pin!(shutdown_signal);
         tokio::pin!(grey_list_clear_interval);
         tokio::pin!(black_list_clear_interval);
@@ -2496,7 +2515,6 @@ where S: ShareChain
 
         let uptime = Instant::now();
         loop {
-            // info!(target: LOG_TARGET, "P2P service main loop iter");
             select! {
                 // biased;
                 _ = &mut shutdown_signal => {
@@ -2506,17 +2524,12 @@ where S: ShareChain
                 req = self.query_rx.recv() => {
                     let timer = Instant::now();
                     match req {
-                        Some(req) => {
-                    self.handle_query(req).await;
-                    },
-                    None => {
-                         warn!(target: LOG_TARGET, "Failed to receive query from channel. Sender dropped?");
+                        Some(req) => self.handle_query(req).await,
+                        None => warn!(target: LOG_TARGET, "Failed to receive query from channel. Sender dropped?"),
                     }
-                                   }
-                     if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
+                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
                         warn!(target: LOG_TARGET, "Query handling took too long: {:?}", timer.elapsed());
                     }
-
                 },
                 _ = seek_connections_interval.tick() => {
                     let timer = Instant::now();
@@ -2524,20 +2537,17 @@ where S: ShareChain
                         let info = self.swarm.network_info();
                         let counters = info.connection_counters();
 
-                        // let num_connections = counters.num_established_incoming() + counters.num_established_outgoing();
                         let num_connections = counters.num_established_outgoing();
                         if num_connections > 8 {
                             continue;
                         }
-                         if num_connections == 0 && uptime.elapsed() < Duration::from_secs(60) {
-
+                        if num_connections == 0 && uptime.elapsed() < Duration::from_secs(60) {
                             match self.dial_seed_peers().await {
                                 Ok(_) => {},
                                 Err(e) => {
                                     warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
                                 },
                             }
-                            // continue;
                          }
 
                         let mut num_dialed = 0;
@@ -2546,22 +2556,23 @@ where S: ShareChain
                         let mut peers_to_dial = vec![];
                         for record in store_write_lock.best_peers_to_dial(100) {
                             // Only dial seed peers if we have 0 connections
-                            if !self.swarm.is_connected(&record.peer_id)
-                             &&  !store_write_lock.is_seed_peer(&record.peer_id)  {
-                                // if &record.peer_id.to_string() != "12D3KooWD6GY3c8cz6AwKaDaqmqGCbmewhjKT5ULN9JUB5oUgWjS" {
-                                // store_write_lock.update_last_dial_attempt(&record.peer_id);
-                                   // info!(target: LOG_TARGET, "Skipping dialing peer: {:?} with height(rx/sha) {}/{} on {}", record.peer_id, record.peer_info.current_random_x_height, record.peer_info.current_sha3x_height, record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", "));
-                                    // continue;
-                                // }
+                            if !self.swarm.is_connected(&record.peer_id) &&
+                                !store_write_lock.is_seed_peer(&record.peer_id)
+                            {
                                 store_write_lock.update_last_dial_attempt(&record.peer_id);
-                                info!(target: LOG_TARGET, "Dialing peer: {:?} with height(rx/sha) {}/{} on {}", record.peer_id, record.peer_info.current_random_x_height, record.peer_info.current_sha3x_height, record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", "));
-                                let dial_opts=  DialOpts::peer_id(record.peer_id).addresses(record.peer_info.public_addresses().clone()).extend_addresses_through_behaviour().build();
-                                // let dial_opts=  DialOpts::peer_id(record.peer_id).addresses(vec!["/ip4/152.228.210.16/tcp/19001/p2p/12D3KooWD6GY3c8cz6AwKaDaqmqGCbmewhjKT5ULN9JUB5oUgWjS".parse().unwrap(), "/ip4/152.228.210.16/udp/19001/quic-v1/p2p/12D3KooWD6GY3c8cz6AwKaDaqmqGCbmewhjKT5ULN9JUB5oUgWjS".parse().unwrap()]).build();
-                                // let dial_opts = DialOpts::unknown_peer_id().address("/ip4/152.228.210.16/tcp/19001/p2p/12D3KooWD6GY3c8cz6AwKaDaqmqGCbmewhjKT5ULN9JUB5oUgWjS".parse().unwrap()).build();
+                                info!(
+                                    target: LOG_TARGET,
+                                    "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
+                                    record.peer_id, record.peer_info.current_random_x_height,
+                                    record.peer_info.current_sha3x_height,
+                                    record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
+                                );
+                                let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
+                                    record.peer_info.public_addresses().clone()
+                                ).extend_addresses_through_behaviour().build();
                                 let _unused = self.swarm.dial(dial_opts).map_err(|e| {
                                     warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
                                 });
-                                // self.initiate_direct_peer_exchange(&record.peer_id).await;
                                 peers_to_dial.push(record.peer_id);
                                 num_dialed += 1;
                                 // We can only do 30 connections
@@ -2570,14 +2581,9 @@ where S: ShareChain
                                     break;
                                 }
                             }
-
-
                         }
                         drop(store_write_lock);
-                        // for peer in peers_to_dial {
-                        //     self.initiate_direct_peer_exchange(&peer).await;
-                        // }
-                     }
+                    }
                     if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
                         warn!(target: LOG_TARGET, "Seeking connections took too long: {:?}", timer.elapsed());
                     }
@@ -2596,7 +2602,6 @@ where S: ShareChain
                         warn!(target: LOG_TARGET, "Inner request handling took too long: {:?}", timer.elapsed());
                     }
                 }
-
                 blocks = self.client_broadcast_block_rx.recv() => {
                     let timer = Instant::now();
                     self.broadcast_block(blocks).await;
@@ -2633,15 +2638,12 @@ where S: ShareChain
                         for peer in connected_peers.iter().take(NUM_PEERS_TO_META_DATA_EXCHANGE) {
                             // Update their latest tip.
                             self.initiate_meta_data_exchange(peer).await;
-
                         }
-                        // self.try_sync_from_best_peer().await;
                     }
                     if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
                         warn!(target: LOG_TARGET, "Chain height exchange took too long: {:?}", timer.elapsed());
                     }
                 },
-
                 _ = peer_exchange_interval.tick() =>  {
                     let timer = Instant::now();
                     if !self.config.is_seed_peer && self.config.sync_job_enabled {
@@ -2651,9 +2653,7 @@ where S: ShareChain
                         for peer in connected_peers.iter().take(NUM_PEERS_TO_PEER_INFO_EXCHANGE) {
                             // Update their latest tip.
                             self.initiate_direct_peer_exchange(peer).await;
-
                         }
-                        // self.try_sync_from_best_peer().await;
                     }
                     if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
                         warn!(target: LOG_TARGET, "Chain height exchange took too long: {:?}", timer.elapsed());
@@ -2675,21 +2675,573 @@ where S: ShareChain
                 },
                 _ = connection_stats_publish.tick() => {
                     let timer = Instant::now();
-                   let connection_info = self.get_libp2p_connection_info();
-                   let _unused = self.stats_broadcast_client.send_libp2p_stats(
-                    connection_info.network_info.connection_counters.pending_incoming,
-                    connection_info.network_info.connection_counters.pending_outgoing,
-                    connection_info.network_info.connection_counters.established_incoming,
-                    connection_info.network_info.connection_counters.established_outgoing,
-                   );
-                   if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
+                    let connection_info = self.get_libp2p_connection_info();
+                    let _unused = self.stats_broadcast_client.send_libp2p_stats(
+                        connection_info.network_info.connection_counters.pending_incoming,
+                        connection_info.network_info.connection_counters.pending_outgoing,
+                        connection_info.network_info.connection_counters.established_incoming,
+                        connection_info.network_info.connection_counters.established_outgoing,
+                    );
+                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
                         warn!(target: LOG_TARGET, "Publishing connection stats took too long: {:?}", timer.elapsed());
                     }
                 },
                 _ = debug_chain_graph.tick() => {
-                 if self.config.debug_print_chain {
-                    self.print_debug_chain_graph().await;
-                 }
+                    if self.config.debug_print_chain {
+                        self.print_debug_chain_graph().await;
+                    }
+                },
+            }
+        }
+    }
+
+    async fn get_connected_peer_records(&self) -> (Vec<PeerStoreRecord>, Vec<PeerStoreRecord>, Vec<PeerStoreRecord>) {
+        let connected_peers = self.swarm.connected_peers().copied().collect::<Vec<_>>();
+        let network_peer_store = self.network_peer_store.read().await;
+        // All connected peers
+        let connected_peer_records: Vec<_> = connected_peers
+            .iter()
+            .filter_map(|peer| network_peer_store.get(peer).cloned())
+            .collect();
+        // Seeds
+        let seeds = connected_peer_records
+            .iter()
+            .filter(|p| network_peer_store.is_seed_peer(&p.peer_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        // Same squad only
+        let same_squad_connected_peer_records = connected_peer_records
+            .iter()
+            .filter(|p| p.peer_info.squad == self.squad)
+            .cloned()
+            .collect::<Vec<_>>();
+        // All other peers
+        let other_peers = same_squad_connected_peer_records
+            .iter()
+            .filter(|p| !network_peer_store.is_seed_peer(&p.peer_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        // Peers without public addresses
+        let peers = other_peers
+            .iter()
+            .filter(|p| p.peer_info.public_addresses().is_empty())
+            .cloned()
+            .collect::<Vec<_>>();
+        // Relay peers
+        let relays = other_peers
+            .iter()
+            .filter(|p| !p.peer_info.public_addresses().is_empty())
+            .cloned()
+            .collect::<Vec<_>>();
+        (seeds, peers, relays)
+    }
+
+    /// Main loop of the service that drives the events and libp2p swarm forward.
+    #[allow(clippy::too_many_lines)]
+    async fn main_loop_diagnostic_mode(&mut self) -> Result<(), Error> {
+        #[derive(Debug)]
+        enum DiagnosticState {
+            ConnectToSeedPeers,
+            InitiateSeedPeersDownload,
+            WaitForSeedPeersDownload,
+            ConnectToPeers,
+            InitiatePeersDownload,
+            WaitForPeersDownload,
+            ConnectToRelayPeers,
+            InitiateRelayPeersDownload,
+            WaitForRelayPeersDownload,
+            Done,
+        }
+
+        let mut publish_peer_info_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + self.config.peer_info_publish_interval,
+            self.config.peer_info_publish_interval,
+        );
+        publish_peer_info_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let mut connection_stats_publish = tokio::time::interval(Duration::from_secs(10));
+        connection_stats_publish.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let mut diagnostic_mode_interval = tokio::time::interval(Duration::from_secs(1));
+        diagnostic_mode_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let shutdown_signal = self.shutdown.to_signal().clone();
+        tokio::pin!(shutdown_signal);
+        tokio::pin!(connection_stats_publish);
+        tokio::pin!(diagnostic_mode_interval);
+
+        let diagnostics_broadcast_client = self
+            .diagnostics_broadcast_client
+            .clone()
+            .ok_or_else(|| anyhow_error("Diagnostics broadcast client not available in diagnostic mode"))?;
+        let diagnostics_receiver_client = self
+            .diagnostics_receiver_client
+            .clone()
+            .ok_or_else(|| anyhow_error("Diagnostics receiver client not available in diagnostic mode"))?;
+        let mut diagnostic_state = DiagnosticState::ConnectToSeedPeers;
+        let mut uptime = Instant::now();
+        let mut processed_peers = Vec::new();
+        loop {
+            select! {
+                // biased;
+                _ = &mut shutdown_signal => {
+                    info!(target: LOG_TARGET,"[Diagnostics] Shutting down p2p service...");
+                    return Ok(());
+                }
+                _ = diagnostic_mode_interval.tick() => {
+                    match diagnostic_state {
+                        DiagnosticState::ConnectToSeedPeers => {
+                            info!(target: LOG_TARGET, "[Diagnostics] Dialing seed peers...");
+                            let seed_peers = self.parse_seed_peers().await?;
+                            let mut number_dialed = 0;
+                            for (peer, addr) in &seed_peers {
+                                info!(target: LOG_TARGET, "[Diagnostics] Adding seed peer: {:?} -> {:?}", peer, addr);
+                                let timer = Instant::now();
+                                self.swarm.add_peer_address(*peer, addr.clone());
+                                match self.swarm.dial(DialOpts::peer_id(*peer).build()) {
+                                    Ok(_) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_seed_peer(
+                                            *peer,
+                                            timer.elapsed(),
+                                            true,
+                                        );
+                                        self.network_peer_store.write().await.add_seed_peers(vec![*peer]);
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] Successfully dialed seed peer '{peer}' at '{addr}'"
+                                        );
+                                        number_dialed += 1;
+                                    },
+                                    Err(e) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_seed_peer(
+                                            *peer,
+                                            timer.elapsed(),
+                                            false,
+                                        );
+                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial seed peer: {e:?}");
+                                    },
+                                }
+                                processed_peers.push(*peer);
+                            }
+
+                            if number_dialed > 0 {
+                                diagnostic_state = DiagnosticState::InitiateSeedPeersDownload;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no seed peers could be dialed, exiting.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::InitiateSeedPeersDownload => {
+                            let (seeds, _peers, _relays) = self.get_connected_peer_records().await;
+                            for peer in &seeds {
+                                self.initiate_direct_peer_exchange(&peer.peer_id).await;
+                                let _unused = diagnostics_broadcast_client.send_new_seed_peer_request(peer.peer_id);
+                            }
+
+                            if !seeds.is_empty() {
+                                diagnostic_state = DiagnosticState::WaitForSeedPeersDownload;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no seed peers connected, exiting.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::WaitForSeedPeersDownload => {
+                            let (mut seen_all, mut seen_some) = (true, false);
+                            if let Ok(seeds_data) = diagnostics_receiver_client.get_seed_peer_diagnostic_info().await {
+                                seeds_data.iter().for_each(|(_peer, data)| {
+                                    if data.number_of_peers.is_none() {
+                                        seen_all = false;
+                                    }
+                                });
+                                seeds_data.iter().for_each(|(_peer, data)| {
+                                    if data.number_of_peers.is_some() {
+                                        seen_some = true;
+                                    }
+                                });
+                            }
+
+                            if seen_all {
+                                diagnostic_state = DiagnosticState::ConnectToPeers;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) && seen_some {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} sporadic, not all seed peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToPeers;
+                            } else {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no seed peers responded, exiting.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            }
+                        }
+                        DiagnosticState::ConnectToPeers => {
+                            let network_peer_store = self.network_peer_store.read().await;
+                            let other_peers = network_peer_store.get_known_peers();
+                            let mut other_peers = other_peers.iter().collect_vec();
+                            // Retain only peers that have not been processed
+                            other_peers.retain(|p| !processed_peers.contains(p));
+                            let other_peer_records: Vec<_> = other_peers
+                                .iter()
+                                .filter_map(|peer| network_peer_store.get(peer).cloned())
+                                .collect();
+                            // Retain only peers that have no public addresses
+                            let peer_records = other_peer_records
+                                .iter()
+                                .filter(|p| p.peer_info.public_addresses().is_empty())
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            // Select 5 random peers
+                            let peer_records = peer_records.choose_multiple(&mut thread_rng(), 5).collect_vec();
+
+                            let mut number_dialed = 0;
+                            for record in &peer_records {
+                                let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
+                                    record.peer_info.public_addresses().clone()
+                                ).extend_addresses_through_behaviour().build();
+                                let timer = Instant::now();
+                                match self.swarm.dial(dial_opts) {
+                                    Ok(_) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_peer(
+                                            record.peer_id,
+                                            timer.elapsed(),
+                                            true,
+                                        );
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] Successfully dialed peer '{:?}'",
+                                            record.peer_id
+                                        );
+                                        number_dialed += 1;
+                                    },
+                                    Err(e) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_peer(
+                                            record.peer_id,
+                                            timer.elapsed(),
+                                            false,
+                                        );
+                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial peer: {e:?}");
+                                    },
+                                };
+                                processed_peers.push(record.peer_id);
+                            }
+
+                            if number_dialed > 0 {
+                                diagnostic_state = DiagnosticState::InitiatePeersDownload;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no non-public peers could be dialed.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::InitiatePeersDownload => {
+                            let mut initiated = 0;
+                            if let Ok(peers_data) = diagnostics_receiver_client.get_peer_diagnostic_info().await {
+                                let chosen_peers = peers_data
+                                    .iter()
+                                    .filter(|(_peer, data)| data.connected_at.is_some())
+                                    .map(|(_peer, data)| data.peer_id)
+                                    .collect::<Vec<_>>();
+                                let (_seeds, connected_peers, _relays) = self.get_connected_peer_records().await;
+                                for peer in &chosen_peers {
+                                    if connected_peers.iter().map(|p| p.peer_id).contains(peer) {
+                                        self.initiate_direct_peer_exchange(peer).await;
+                                        let _unused = diagnostics_broadcast_client.send_new_peer_request(*peer);
+                                        initiated += 1;
+                                    }
+                                }
+                            }
+                            if initiated > 0{
+                                diagnostic_state = DiagnosticState::WaitForPeersDownload;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no non-public peers connected.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::WaitForPeersDownload => {
+                            let (mut seen_all, mut seen_some) = (true, false);
+                            if let Ok(peers_data) = diagnostics_receiver_client.get_peer_diagnostic_info().await {
+                                peers_data.iter().for_each(|(_peer, data)| {
+                                    if data.number_of_peers.is_none() {
+                                        seen_all = false;
+                                    }
+                                });
+                                peers_data.iter().for_each(|(_peer, data)| {
+                                    if data.number_of_peers.is_some() {
+                                        seen_some = true;
+                                    }
+                                });
+                            }
+
+                            if seen_all {
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) && seen_some {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} sporadic, not all peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                            } else {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            }
+                        }
+                        DiagnosticState::ConnectToRelayPeers => {
+                            let network_peer_store = self.network_peer_store.read().await;
+                            let other_peers = network_peer_store.get_known_peers();
+                            let mut other_peers = other_peers.iter().collect_vec();
+                            // Retain only peers that have not been processed
+                            other_peers.retain(|p| !processed_peers.contains(p));
+                            let other_peer_records: Vec<_> = other_peers
+                                .iter()
+                                .filter_map(|peer| network_peer_store.get(peer).cloned())
+                                .collect();
+                            // Retain only peers that have public addresses
+                            let peer_records = other_peer_records
+                                .iter()
+                                .filter(|p| !p.peer_info.public_addresses().is_empty())
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            // Select 5 random peers
+                            let peer_records = peer_records.choose_multiple(&mut thread_rng(), 5).collect_vec();
+
+                            let mut number_dialed = 0;
+                            for record in &peer_records {
+                                let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
+                                    record.peer_info.public_addresses().clone()
+                                ).extend_addresses_through_behaviour().build();
+                                let timer = Instant::now();
+                                match self.swarm.dial(dial_opts) {
+                                    Ok(_) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_relay_peer(
+                                            record.peer_id,
+                                            timer.elapsed(),
+                                            true,
+                                        );
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] Successfully dialed peer '{:?}'",
+                                            record.peer_id
+                                        );
+                                        number_dialed += 1;
+                                    },
+                                    Err(e) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_relay_peer(
+                                            record.peer_id,
+                                            timer.elapsed(),
+                                            false,
+                                        );
+                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial peer: {e:?}");
+                                    },
+                                };
+                                processed_peers.push(record.peer_id);
+                            }
+
+                            if number_dialed > 0 {
+                                diagnostic_state = DiagnosticState::InitiateRelayPeersDownload;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no public peers could be dialed. Exiting.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::InitiateRelayPeersDownload => {
+                            let mut initiated = 0;
+                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
+                                let chosen_relays = relays_data
+                                    .iter()
+                                    .filter(|(_peer, data)| data.connected_at.is_some())
+                                    .map(|(_peer, data)| data.peer_id)
+                                    .collect::<Vec<_>>();
+                                let (_seeds, _peers, connected_relays) = self.get_connected_peer_records().await;
+                                for peer in &chosen_relays {
+                                    if connected_relays.iter().map(|p| p.peer_id).contains(peer) {
+                                        self.initiate_direct_peer_exchange(peer).await;
+                                        let _unused = diagnostics_broadcast_client.send_new_relay_peer_request(*peer);
+                                        initiated += 1;
+                                    }
+                                }
+                            }
+                            if initiated > 0{
+                                diagnostic_state = DiagnosticState::WaitForRelayPeersDownload;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no public peers connected.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::WaitForRelayPeersDownload => {
+                            let (mut seen_all, mut seen_some) = (true, false);
+                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
+                                relays_data.iter().for_each(|(_peer, data)| {
+                                    if data.number_of_peers.is_none() {
+                                        seen_all = false;
+                                    }
+                                });
+                                relays_data.iter().for_each(|(_peer, data)| {
+                                    if data.number_of_peers.is_some() {
+                                        seen_some = true;
+                                    }
+                                });
+                            }
+
+                            if seen_all {
+                                diagnostic_state = DiagnosticState::Done;
+                                uptime = Instant::now();
+                            } else if uptime.elapsed() > Duration::from_secs(60) && seen_some {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} sporadic, not all peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            } else {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::Done;
+                            }
+                        }
+                        DiagnosticState::Done => {
+                            // Print diagnostics to json file
+                            let seeds_data = diagnostics_receiver_client
+                                .get_seed_peer_diagnostic_info()
+                                .await
+                                .unwrap_or_default().values().cloned()
+                                .collect::<Vec<DiagnosticPeerInfo>>();
+                            let peers_data = diagnostics_receiver_client
+                                .get_peer_diagnostic_info()
+                                .await
+                                .unwrap_or_default().values().cloned()
+                                .collect::<Vec<DiagnosticPeerInfo>>();
+                            let relays_data = diagnostics_receiver_client
+                                .get_relay_peer_diagnostic_info()
+                                .await
+                                .unwrap_or_default().values().cloned()
+                                .collect::<Vec<DiagnosticPeerInfo>>();
+                            let diagnostics = json!({
+                                "seeds": seeds_data,
+                                "peers": peers_data,
+                                "relays": relays_data,
+                            });
+
+                            let file_path =  PathBuf::from("./diagnostic_results.json");
+                            let mut file = File::create(file_path.clone())?;
+                            write!(file, "{}", diagnostics)?;
+                            info!(target: LOG_TARGET, "Diagnostics written to file: {}", file_path.display());
+
+                            // Send shutdown signal
+                            self.shutdown.trigger();
+                        },
+                    }
+                },
+                req = self.query_rx.recv() => {
+                    let timer = Instant::now();
+                    match req {
+                        Some(P2pServiceQuery::GetChain {..}) =>
+                            warn!(target: LOG_TARGET, "[Diagnostics] ignoring 'P2pServiceQuery::GetChain'"),
+                        Some(req) => self.handle_query(req).await,
+                        None =>
+                            warn!(
+                                target: LOG_TARGET,
+                                "[Diagnostics] Failed to receive query from channel. Sender dropped?"
+                            ),
+                    }
+                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
+                        warn!(target: LOG_TARGET, "[Diagnostics] Query handling took too long: {:?}", timer.elapsed());
+                    }
+                },
+                _inner_req = self.inner_request_rx.recv() => {
+                    warn!(target: LOG_TARGET, "[Diagnostics] Ignoring inner request");
+                }
+                _blocks = self.client_broadcast_block_rx.recv() => {
+                    warn!(target: LOG_TARGET, "[Diagnostics] Ignoring broadcast blocks");
+                },
+                event = self.swarm.select_next_some() => {
+                    let timer = Instant::now();
+                    match event {
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::MetaDataExchange(_) ) => {
+                            warn!(target: LOG_TARGET, "[Diagnostics] Ignoring MetaDataExchange events");
+                        },
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::ShareChainSync(_)) => {
+                            warn!(target: LOG_TARGET, "[Diagnostics] Ignoring ShareChainSync events");
+                        },
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::CatchUpSync(_)) => {
+                            warn!(target: LOG_TARGET, "[Diagnostics] Ignoring CatchUpSync events");
+                        },
+                        _ => self.handle_event(event).await,
+                    }
+                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
+                        warn!(target: LOG_TARGET, "[Diagnostics] Event handling took too long: {:?}", timer.elapsed());
+                    }
+                 },
+                _ = connection_stats_publish.tick() => {
+                    let timer = Instant::now();
+                    let connection_info = self.get_libp2p_connection_info();
+                    let _unused = self.stats_broadcast_client.send_libp2p_stats(
+                        connection_info.network_info.connection_counters.pending_incoming,
+                        connection_info.network_info.connection_counters.pending_outgoing,
+                        connection_info.network_info.connection_counters.established_incoming,
+                        connection_info.network_info.connection_counters.established_outgoing,
+                    );
+                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
+                        warn!(
+                            target: LOG_TARGET,
+                            "[Diagnostics] Publishing connection stats took too long: {:?}",
+                            timer.elapsed()
+                        );
+                    }
                 },
             }
         }
@@ -2837,7 +3389,7 @@ where S: ShareChain
     }
 
     /// Adding all peer addresses to kademlia DHT and run bootstrap to get peers.
-    async fn join_seed_peers(&mut self, seed_peers: HashMap<PeerId, Multiaddr>) -> Result<(), Error> {
+    async fn join_seed_peers(&mut self, seed_peers: HashMap<PeerId, Multiaddr>) {
         let mut peers_to_add = Vec::with_capacity(seed_peers.len());
         seed_peers.iter().for_each(|(peer_id, addr)| {
             info!(target: LOG_TARGET, "Adding seed peer: {:?} -> {:?}", peer_id, addr);
@@ -2849,12 +3401,6 @@ where S: ShareChain
             });
         });
         self.network_peer_store.write().await.add_seed_peers(peers_to_add);
-
-        // if !seed_peers.is_empty() {
-        // self.bootstrap_kademlia()?;
-        // }
-
-        Ok(())
     }
 
     fn parse_dnsaddr_txt(&self, txt: &[u8]) -> Result<Multiaddr, Error> {
@@ -2872,7 +3418,7 @@ where S: ShareChain
     pub async fn dial_seed_peers(&mut self) -> Result<(), Error> {
         info!(target: LOG_TARGET, "Dialing seed peers...");
         let seed_peers = self.parse_seed_peers().await?;
-        self.join_seed_peers(seed_peers).await?;
+        self.join_seed_peers(seed_peers).await;
         Ok(())
     }
 
@@ -2903,30 +3449,14 @@ where S: ShareChain
         }
         self.subscribe_to_topics().await;
 
-        self.dial_seed_peers().await?;
-        // let seed_peers = self.parse_seed_peers().await?;
-        // self.join_seed_peers(seed_peers).await?;
-
-        // start initial share chain sync
-        // let in_progress = self.sync_in_progress.clone();
-        warn!(target: LOG_TARGET, "Starting initial share chain sync...");
-        // tokio::spawn(async move {
-        //     Self::initial_share_chain_sync(
-        //         in_progress,
-        //         peer_store,
-        //         share_chain_sha3x,
-        //         share_chain_random_x,
-        //         share_chain_sync_tx,
-        //         Duration::from_secs(3),
-        //         squad,
-        //         shutdown_signal,
-        //     )
-        //     .await;
-        // });
-
-        warn!(target: LOG_TARGET, "Starting main loop");
-
-        self.main_loop().await?;
+        if self.config.diagnostic_mode {
+            debug!(target: LOG_TARGET, "Starting diagnostic loop");
+            self.main_loop_diagnostic_mode().await?;
+        } else {
+            self.dial_seed_peers().await?;
+            debug!(target: LOG_TARGET, "Starting main loop");
+            self.main_loop().await?;
+        }
         info!(target: LOG_TARGET,"P2P service has been stopped!");
         Ok(())
     }

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -3265,43 +3265,15 @@ where S: ShareChain
                         },
                     }
                 },
-                req = self.query_rx.recv() => {
-                    let timer = Instant::now();
-                    match req {
-                        Some(P2pServiceQuery::GetChain {..}) =>
-                        debug!(target: LOG_TARGET, "[Diagnostics] ignoring 'P2pServiceQuery::GetChain'"),
-                        Some(req) => self.handle_query(req).await,
-                        None =>
-                            warn!(
-                                target: LOG_TARGET,
-                                "[Diagnostics] Failed to receive query from channel. Sender dropped?"
-                            ),
-                    }
-                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
-                        warn!(target: LOG_TARGET, "[Diagnostics] Query handling took too long: {:?}", timer.elapsed());
-                    }
-                },
-                _inner_req = self.inner_request_rx.recv() => {
-                    debug!(target: LOG_TARGET, "[Diagnostics] Ignoring inner request");
-                }
-                _blocks = self.client_broadcast_block_rx.recv() => {
-                    debug!(target: LOG_TARGET, "[Diagnostics] Ignoring broadcast blocks");
-                },
                 event = self.swarm.select_next_some() => {
                     let timer = Instant::now();
                     match event {
-                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::MetaDataExchange(_) ) => {
-                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring MetaDataExchange events");
-                        },
-                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::ShareChainSync(_)) => {
-                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring ShareChainSync events");
-                        },
-                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::CatchUpSync(_)) => {
-                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring CatchUpSync events");
-                        },
-                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::Gossipsub(_)) => {
-                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring Gossipsub events");
-                        },
+                        // These events must be ignored in diagnostic mode
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::MetaDataExchange(_) ) |
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::ShareChainSync(_)) |
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::CatchUpSync(_)) |
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::Gossipsub(_)) => {},
+                        // Other events must be handled
                         _ => self.handle_event(event).await,
                     }
                     if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
@@ -3499,15 +3471,10 @@ where S: ShareChain
 
     pub async fn dial_seed_peers(&mut self) -> Result<(), Error> {
         info!(target: LOG_TARGET, "Dialing seed peers...");
-        match self.parse_seed_peers().await {
-            Ok(seed_peers) => {
-                self.join_seed_peers(seed_peers).await;
-            },
-            Err(e) => {
-                warn!(target: LOG_TARGET, "Failed to parse seed peers: {e:?}");
-                return Err(e);
-            },
-        }
+        let seed_peers = self.parse_seed_peers().await.inspect_err(|e| {
+            warn!(target: LOG_TARGET, "Failed to parse seed peers: {e:?}");
+        })?;
+        self.join_seed_peers(seed_peers).await;
         Ok(())
     }
 

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -41,7 +41,7 @@ use log::{debug, error, info, trace, warn};
 use lru::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, to_writer_pretty};
 use tari_common::configuration::Network;
 use tari_common_types::types::FixedHash;
 use tari_core::proof_of_work::PowAlgorithm;
@@ -140,6 +140,7 @@ pub struct Config {
     pub num_sync_tips_to_keep: usize,
     pub max_missing_blocks_sync_depth: usize,
     pub diagnostic_mode: bool,
+    pub diagnostic_mode_file_path: Option<PathBuf>,
 }
 
 impl Default for Config {
@@ -170,6 +171,7 @@ impl Default for Config {
             num_sync_tips_to_keep: 10,
             max_missing_blocks_sync_depth: 8,
             diagnostic_mode: false,
+            diagnostic_mode_file_path: None,
         }
     }
 }
@@ -1080,6 +1082,7 @@ where S: ShareChain
                 //     self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
                 // }
                 let mut num_peers_added = 0;
+                let num_peers_received = response.best_peers.len();
                 for mut peer in response.best_peers {
                     debug!(
                         target: LOG_TARGET,
@@ -1105,9 +1108,9 @@ where S: ShareChain
                     return;
                 }
 
-                // Update peer stats
+                // Update peer diagnostics
                 if let Some(client) = &self.diagnostics_broadcast_client {
-                    let _unused = client.send_peer_response(peer_id, num_peers_added);
+                    let _unused = client.send_peer_response(peer_id, num_peers_received);
                 }
 
                 // if we are a seed peer, end here
@@ -1412,8 +1415,14 @@ where S: ShareChain
                     target: LOG_TARGET,
                     "Connection established: {peer_id:?} -> {endpoint:?} ({num_established:?}/{concurrent_dial_errors:?}/{established_in:?})"
                 );
+                if let Some(client) = &self.diagnostics_broadcast_client {
+                    let _unused = client.send_peer_connected(peer_id);
+                }
                 // if num_established == NonZeroU32::new(1).expect("Can't fail") {
                 self.initiate_direct_peer_exchange(&peer_id).await;
+                if let Some(client) = &self.diagnostics_broadcast_client {
+                    let _unused = client.send_new_peer_request(peer_id);
+                }
                 // self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
                 // }
             },
@@ -2542,11 +2551,8 @@ where S: ShareChain
                             continue;
                         }
                         if num_connections == 0 && uptime.elapsed() < Duration::from_secs(60) {
-                            match self.dial_seed_peers().await {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
-                                },
+                            if let Err(e) = self.dial_seed_peers().await {
+                                warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
                             }
                          }
 
@@ -2695,8 +2701,10 @@ where S: ShareChain
         }
     }
 
-    async fn get_connected_peer_records(&self) -> (Vec<PeerStoreRecord>, Vec<PeerStoreRecord>, Vec<PeerStoreRecord>) {
-        let connected_peers = self.swarm.connected_peers().copied().collect::<Vec<_>>();
+    async fn get_connected_peer_records(
+        &self,
+        connected_peers: &[PeerId],
+    ) -> (Vec<PeerStoreRecord>, Vec<PeerStoreRecord>, Vec<PeerStoreRecord>) {
         let network_peer_store = self.network_peer_store.read().await;
         // All connected peers
         let connected_peer_records: Vec<_> = connected_peers
@@ -2736,19 +2744,16 @@ where S: ShareChain
         (seeds, peers, relays)
     }
 
-    /// Main loop of the service that drives the events and libp2p swarm forward.
+    /// Main loop of the diagnostic service that drives the events and libp2p swarm forward.
     #[allow(clippy::too_many_lines)]
     async fn main_loop_diagnostic_mode(&mut self) -> Result<(), Error> {
         #[derive(Debug)]
         enum DiagnosticState {
             ConnectToSeedPeers,
-            InitiateSeedPeersDownload,
             WaitForSeedPeersDownload,
-            ConnectToPeers,
-            InitiatePeersDownload,
-            WaitForPeersDownload,
+            ConnectToPrivatePeers,
+            WaitForPrivatePeersDownload,
             ConnectToRelayPeers,
-            InitiateRelayPeersDownload,
             WaitForRelayPeersDownload,
             Done,
         }
@@ -2779,7 +2784,8 @@ where S: ShareChain
             .clone()
             .ok_or_else(|| anyhow_error("Diagnostics receiver client not available in diagnostic mode"))?;
         let mut diagnostic_state = DiagnosticState::ConnectToSeedPeers;
-        let mut uptime = Instant::now();
+        let mut start = Instant::now();
+        let uptime = Instant::now();
         let mut processed_peers = Vec::new();
         loop {
             select! {
@@ -2791,7 +2797,7 @@ where S: ShareChain
                 _ = diagnostic_mode_interval.tick() => {
                     match diagnostic_state {
                         DiagnosticState::ConnectToSeedPeers => {
-                            info!(target: LOG_TARGET, "[Diagnostics] Dialing seed peers...");
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
                             let seed_peers = self.parse_seed_peers().await?;
                             let mut number_dialed = 0;
                             for (peer, addr) in &seed_peers {
@@ -2825,9 +2831,9 @@ where S: ShareChain
                             }
 
                             if number_dialed > 0 {
-                                diagnostic_state = DiagnosticState::InitiateSeedPeersDownload;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                diagnostic_state = DiagnosticState::WaitForSeedPeersDownload;
+                                start = Instant::now();
+                            } else if start.elapsed() > Duration::from_secs(60) {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} failed, no seed peers could be dialed, exiting.",
@@ -2838,192 +2844,66 @@ where S: ShareChain
                                 // Nothing here
                             }
                         },
-                        DiagnosticState::InitiateSeedPeersDownload => {
-                            let (seeds, _peers, _relays) = self.get_connected_peer_records().await;
-                            for peer in &seeds {
-                                self.initiate_direct_peer_exchange(&peer.peer_id).await;
-                                let _unused = diagnostics_broadcast_client.send_new_seed_peer_request(peer.peer_id);
+                        DiagnosticState::WaitForSeedPeersDownload => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
+                                let (seeds, _privates, _relays) = self.get_connected_peer_records(&connected_peers).await;
+                                if seeds.is_empty() {
+                                    if start.elapsed() > Duration::from_secs(30) {
+                                        warn!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] {:?} failed, no seed peers connected",
+                                            diagnostic_state
+                                        );
+                                        diagnostic_state = DiagnosticState::Done;
+                                    } else {
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] {:?} waiting for seed peers to connect...",
+                                            diagnostic_state
+                                        );
+                                        continue;
+                                    }
+                                }
                             }
 
-                            if !seeds.is_empty() {
-                                diagnostic_state = DiagnosticState::WaitForSeedPeersDownload;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no seed peers connected, exiting.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::Done;
-                            } else {
-                                // Nothing here
-                            }
-                        },
-                        DiagnosticState::WaitForSeedPeersDownload => {
                             let (mut seen_all, mut seen_some) = (true, false);
                             if let Ok(seeds_data) = diagnostics_receiver_client.get_seed_peer_diagnostic_info().await {
                                 seeds_data.iter().for_each(|(_peer, data)| {
-                                    if data.number_of_peers.is_none() {
+                                    if data.response_time.is_none() {
                                         seen_all = false;
                                     }
                                 });
                                 seeds_data.iter().for_each(|(_peer, data)| {
-                                    if data.number_of_peers.is_some() {
+                                    if data.response_time.is_some() {
                                         seen_some = true;
                                     }
                                 });
                             }
 
                             if seen_all {
-                                diagnostic_state = DiagnosticState::ConnectToPeers;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) && seen_some {
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                                start = Instant::now();
+                            } else if start.elapsed() > Duration::from_secs(60) && seen_some {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} sporadic, not all seed peers responded.",
                                     diagnostic_state
                                 );
-                                diagnostic_state = DiagnosticState::ConnectToPeers;
-                            } else {
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                            } else if start.elapsed() > Duration::from_secs(60) {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} failed, no seed peers responded, exiting.",
                                     diagnostic_state
                                 );
                                 diagnostic_state = DiagnosticState::Done;
-                            }
-                        }
-                        DiagnosticState::ConnectToPeers => {
-                            let network_peer_store = self.network_peer_store.read().await;
-                            let other_peers = network_peer_store.get_known_peers();
-                            let mut other_peers = other_peers.iter().collect_vec();
-                            // Retain only peers that have not been processed
-                            other_peers.retain(|p| !processed_peers.contains(p));
-                            let other_peer_records: Vec<_> = other_peers
-                                .iter()
-                                .filter_map(|peer| network_peer_store.get(peer).cloned())
-                                .collect();
-                            // Retain only peers that have no public addresses
-                            let peer_records = other_peer_records
-                                .iter()
-                                .filter(|p| p.peer_info.public_addresses().is_empty())
-                                .cloned()
-                                .collect::<Vec<_>>();
-                            // Select 5 random peers
-                            let peer_records = peer_records.choose_multiple(&mut thread_rng(), 5).collect_vec();
-
-                            let mut number_dialed = 0;
-                            for record in &peer_records {
-                                let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
-                                    record.peer_info.public_addresses().clone()
-                                ).extend_addresses_through_behaviour().build();
-                                let timer = Instant::now();
-                                match self.swarm.dial(dial_opts) {
-                                    Ok(_) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_peer(
-                                            record.peer_id,
-                                            timer.elapsed(),
-                                            true,
-                                        );
-                                        debug!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] Successfully dialed peer '{:?}'",
-                                            record.peer_id
-                                        );
-                                        number_dialed += 1;
-                                    },
-                                    Err(e) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_peer(
-                                            record.peer_id,
-                                            timer.elapsed(),
-                                            false,
-                                        );
-                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial peer: {e:?}");
-                                    },
-                                };
-                                processed_peers.push(record.peer_id);
-                            }
-
-                            if number_dialed > 0 {
-                                diagnostic_state = DiagnosticState::InitiatePeersDownload;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no non-public peers could be dialed.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
                             } else {
                                 // Nothing here
-                            }
-                        },
-                        DiagnosticState::InitiatePeersDownload => {
-                            let mut initiated = 0;
-                            if let Ok(peers_data) = diagnostics_receiver_client.get_peer_diagnostic_info().await {
-                                let chosen_peers = peers_data
-                                    .iter()
-                                    .filter(|(_peer, data)| data.connected_at.is_some())
-                                    .map(|(_peer, data)| data.peer_id)
-                                    .collect::<Vec<_>>();
-                                let (_seeds, connected_peers, _relays) = self.get_connected_peer_records().await;
-                                for peer in &chosen_peers {
-                                    if connected_peers.iter().map(|p| p.peer_id).contains(peer) {
-                                        self.initiate_direct_peer_exchange(peer).await;
-                                        let _unused = diagnostics_broadcast_client.send_new_peer_request(*peer);
-                                        initiated += 1;
-                                    }
-                                }
-                            }
-                            if initiated > 0{
-                                diagnostic_state = DiagnosticState::WaitForPeersDownload;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no non-public peers connected.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
-                            } else {
-                                // Nothing here
-                            }
-                        },
-                        DiagnosticState::WaitForPeersDownload => {
-                            let (mut seen_all, mut seen_some) = (true, false);
-                            if let Ok(peers_data) = diagnostics_receiver_client.get_peer_diagnostic_info().await {
-                                peers_data.iter().for_each(|(_peer, data)| {
-                                    if data.number_of_peers.is_none() {
-                                        seen_all = false;
-                                    }
-                                });
-                                peers_data.iter().for_each(|(_peer, data)| {
-                                    if data.number_of_peers.is_some() {
-                                        seen_some = true;
-                                    }
-                                });
-                            }
-
-                            if seen_all {
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) && seen_some {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} sporadic, not all peers responded.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
-                            } else {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no peers responded.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::Done;
                             }
                         }
                         DiagnosticState::ConnectToRelayPeers => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
                             let network_peer_store = self.network_peer_store.read().await;
                             let other_peers = network_peer_store.get_known_peers();
                             let mut other_peers = other_peers.iter().collect_vec();
@@ -3075,12 +2955,136 @@ where S: ShareChain
                             }
 
                             if number_dialed > 0 {
-                                diagnostic_state = DiagnosticState::InitiateRelayPeersDownload;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) {
+                                diagnostic_state = DiagnosticState::WaitForRelayPeersDownload;
+                                start = Instant::now();
+                            } else if start.elapsed() > Duration::from_secs(60) {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} failed, no public peers could be dialed. Exiting.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                            } else {
+                                // Nothing here
+                            }
+                        },
+                        DiagnosticState::WaitForRelayPeersDownload => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
+                                let (_seeds, _privates, relays) = self.get_connected_peer_records(&connected_peers).await;
+                                if relays.is_empty() {
+                                    if start.elapsed() > Duration::from_secs(30) {
+                                        warn!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] {:?} failed, no relay peers connected",
+                                            diagnostic_state
+                                        );
+                                        diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                                    } else {
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] {:?} waiting for relay peers to connect...",
+                                            diagnostic_state
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+
+                            let (mut seen_all, mut seen_some) = (true, false);
+                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
+                                relays_data.iter().for_each(|(_peer, data)| {
+                                    if data.response_time.is_none() {
+                                        seen_all = false;
+                                    }
+                                });
+                                relays_data.iter().for_each(|(_peer, data)| {
+                                    if data.response_time.is_some() {
+                                        seen_some = true;
+                                    }
+                                });
+                            }
+
+                            if seen_all {
+                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                                start = Instant::now();
+                            } else if start.elapsed() > Duration::from_secs(60) && seen_some {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} sporadic, not all peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                            } else if start.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no peers responded.",
+                                    diagnostic_state
+                                );
+                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                            } else {
+                                // Nothing here
+                            }
+                        }
+                        DiagnosticState::ConnectToPrivatePeers => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            let network_peer_store = self.network_peer_store.read().await;
+                            let other_peers = network_peer_store.get_known_peers();
+                            let mut other_peers = other_peers.iter().collect_vec();
+                            // Retain only peers that have not been processed
+                            other_peers.retain(|p| !processed_peers.contains(p));
+                            let other_peer_records: Vec<_> = other_peers
+                                .iter()
+                                .filter_map(|peer| network_peer_store.get(peer).cloned())
+                                .collect();
+                            // Retain only peers that have no public addresses
+                            let peer_records = other_peer_records
+                                .iter()
+                                .filter(|p| p.peer_info.public_addresses().is_empty())
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            // Select 5 random peers
+                            let peer_records = peer_records.choose_multiple(&mut thread_rng(), 5).collect_vec();
+
+                            let mut number_dialed = 0;
+                            for record in &peer_records {
+                                let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
+                                    record.peer_info.public_addresses().clone()
+                                ).extend_addresses_through_behaviour().build();
+                                let timer = Instant::now();
+                                match self.swarm.dial(dial_opts) {
+                                    Ok(_) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_private_peer(
+                                            record.peer_id,
+                                            timer.elapsed(),
+                                            true,
+                                        );
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] Successfully dialed peer '{:?}'",
+                                            record.peer_id
+                                        );
+                                        number_dialed += 1;
+                                    },
+                                    Err(e) => {
+                                        let _unused = diagnostics_broadcast_client.send_new_private_peer(
+                                            record.peer_id,
+                                            timer.elapsed(),
+                                            false,
+                                        );
+                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial peer: {e:?}");
+                                    },
+                                };
+                                processed_peers.push(record.peer_id);
+                            }
+
+                            if number_dialed > 0 {
+                                diagnostic_state = DiagnosticState::WaitForPrivatePeersDownload;
+                                start = Instant::now();
+                            } else if start.elapsed() > Duration::from_secs(60) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] {:?} failed, no non-public peers could be dialed.",
                                     diagnostic_state
                                 );
                                 diagnostic_state = DiagnosticState::Done;
@@ -3088,47 +3092,38 @@ where S: ShareChain
                                 // Nothing here
                             }
                         },
-                        DiagnosticState::InitiateRelayPeersDownload => {
-                            let mut initiated = 0;
-                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
-                                let chosen_relays = relays_data
-                                    .iter()
-                                    .filter(|(_peer, data)| data.connected_at.is_some())
-                                    .map(|(_peer, data)| data.peer_id)
-                                    .collect::<Vec<_>>();
-                                let (_seeds, _peers, connected_relays) = self.get_connected_peer_records().await;
-                                for peer in &chosen_relays {
-                                    if connected_relays.iter().map(|p| p.peer_id).contains(peer) {
-                                        self.initiate_direct_peer_exchange(peer).await;
-                                        let _unused = diagnostics_broadcast_client.send_new_relay_peer_request(*peer);
-                                        initiated += 1;
+                        DiagnosticState::WaitForPrivatePeersDownload => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
+                                let (_seeds, privates, _relays) = self.get_connected_peer_records(&connected_peers).await;
+                                if privates.is_empty() {
+                                    if start.elapsed() > Duration::from_secs(30) {
+                                        warn!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] {:?} failed, no private peers connected",
+                                            diagnostic_state
+                                        );
+                                        diagnostic_state = DiagnosticState::Done;
+                                    } else {
+                                        debug!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] {:?} waiting for private peers to connect...",
+                                            diagnostic_state
+                                        );
+                                        continue;
                                     }
                                 }
                             }
-                            if initiated > 0{
-                                diagnostic_state = DiagnosticState::WaitForRelayPeersDownload;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no public peers connected.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
-                            } else {
-                                // Nothing here
-                            }
-                        },
-                        DiagnosticState::WaitForRelayPeersDownload => {
+
                             let (mut seen_all, mut seen_some) = (true, false);
-                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
-                                relays_data.iter().for_each(|(_peer, data)| {
-                                    if data.number_of_peers.is_none() {
+                            if let Ok(peers_data) = diagnostics_receiver_client.get_private_peer_diagnostic_info().await {
+                                peers_data.iter().for_each(|(_peer, data)| {
+                                    if data.response_time.is_none() {
                                         seen_all = false;
                                     }
                                 });
-                                relays_data.iter().for_each(|(_peer, data)| {
-                                    if data.number_of_peers.is_some() {
+                                peers_data.iter().for_each(|(_peer, data)| {
+                                    if data.response_time.is_some() {
                                         seen_some = true;
                                     }
                                 });
@@ -3136,49 +3131,120 @@ where S: ShareChain
 
                             if seen_all {
                                 diagnostic_state = DiagnosticState::Done;
-                                uptime = Instant::now();
-                            } else if uptime.elapsed() > Duration::from_secs(60) && seen_some {
+                                start = Instant::now();
+                            } else if start.elapsed() > Duration::from_secs(60) && seen_some {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} sporadic, not all peers responded.",
                                     diagnostic_state
                                 );
                                 diagnostic_state = DiagnosticState::Done;
-                            } else {
+                            } else if start.elapsed() > Duration::from_secs(60) {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} failed, no peers responded.",
                                     diagnostic_state
                                 );
                                 diagnostic_state = DiagnosticState::Done;
+                            } else {
+                                // Nothing here
                             }
                         }
                         DiagnosticState::Done => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
                             // Print diagnostics to json file
-                            let seeds_data = diagnostics_receiver_client
+                            let mut seeds_data = diagnostics_receiver_client
                                 .get_seed_peer_diagnostic_info()
                                 .await
-                                .unwrap_or_default().values().cloned()
+                                .unwrap_or_default()
+                                .values()
+                                .cloned()
                                 .collect::<Vec<DiagnosticPeerInfo>>();
-                            let peers_data = diagnostics_receiver_client
-                                .get_peer_diagnostic_info()
+                            seeds_data.sort_by(|a, b| b.number_of_peers.cmp(&a.number_of_peers));
+                            seeds_data = seeds_data.into_iter().take(5).collect::<Vec<_>>();
+
+                            let mut private_peers_data = diagnostics_receiver_client
+                                .get_private_peer_diagnostic_info()
                                 .await
-                                .unwrap_or_default().values().cloned()
+                                .unwrap_or_default()
+                                .values()
+                                .cloned()
                                 .collect::<Vec<DiagnosticPeerInfo>>();
-                            let relays_data = diagnostics_receiver_client
+                            private_peers_data.sort_by(|a, b| b.number_of_peers.cmp(&a.number_of_peers));
+                            private_peers_data = private_peers_data.into_iter().take(5).collect::<Vec<_>>();
+
+                            let mut relays_data = diagnostics_receiver_client
                                 .get_relay_peer_diagnostic_info()
                                 .await
-                                .unwrap_or_default().values().cloned()
+                                .unwrap_or_default()
+                                .values()
+                                .cloned()
                                 .collect::<Vec<DiagnosticPeerInfo>>();
-                            let diagnostics = json!({
-                                "seeds": seeds_data,
-                                "peers": peers_data,
-                                "relays": relays_data,
-                            });
+                            relays_data.sort_by(|a, b| b.number_of_peers.cmp(&a.number_of_peers));
+                            relays_data = relays_data.into_iter().take(5).collect::<Vec<_>>();
 
-                            let file_path =  PathBuf::from("./diagnostic_results.json");
-                            let mut file = File::create(file_path.clone())?;
-                            write!(file, "{}", diagnostics)?;
+                            let diagnostics_data = [
+                                ("seeds", json!({ "seeds": seeds_data })),
+                                ("privates", json!({ "privates": private_peers_data })),
+                                ("relays", json!({ "relays": relays_data }))
+                            ];
+                            let local_node = ("local_node", json!(
+                                {"local_node":
+                                    {
+                                        "peer_id": self.swarm.local_peer_id(),
+                                        "public_addresses": self.swarm.external_addresses().collect::<Vec<_>>(),
+                                    }
+                                })
+                            );
+                            let summary = ("summary", json!(
+                                {
+                                    "summary": {
+                                        "Connect to each DNS seeds":
+                                            seeds_data.iter().any(|peer| peer.dial_succeeded),
+                                        "Download peers from the DNS seeds":
+                                            seeds_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
+                                        "Connect to 5 of private peers":
+                                            private_peers_data.iter().any(|peer| peer.dial_succeeded),
+                                        "Download peers from private seeds":
+                                            private_peers_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
+                                        "Connect to 5 of relay peers":
+                                            relays_data.iter().any(|peer| peer.dial_succeeded),
+                                        "Download peers from relay seeds":
+                                            relays_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0)
+                                    }
+                                })
+                            );
+
+                            let file_path = self.config.diagnostic_mode_file_path.clone().unwrap_or_default().join(
+                                "./diagnostic_results.json"
+                            );
+                            if let Ok(file) = File::create(file_path.clone()) {
+                                if let Err(e) = to_writer_pretty(&file, &local_node.1) {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] Failed to write {} diagnostics to file: {e}",
+                                        local_node.0
+                                    );
+                                }
+                                let _unused = writeln!(&file);
+                                if let Err(e) = to_writer_pretty(&file, &summary.1) {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] Failed to write {} diagnostics to file: {e}",
+                                        summary.0
+                                    );
+                                }
+                                let _unused = writeln!(&file);
+                                for (data_name, diagnostics) in &diagnostics_data {
+                                    if let Err(e) = to_writer_pretty(&file, diagnostics) {
+                                        warn!(
+                                            target: LOG_TARGET,
+                                            "[Diagnostics] Failed to write {data_name} diagnostics to file: {e}",
+                                        );
+                                    }
+                                    let _unused = writeln!(&file);
+                                }
+                            }
                             info!(target: LOG_TARGET, "Diagnostics written to file: {}", file_path.display());
 
                             // Send shutdown signal
@@ -3190,7 +3256,7 @@ where S: ShareChain
                     let timer = Instant::now();
                     match req {
                         Some(P2pServiceQuery::GetChain {..}) =>
-                            warn!(target: LOG_TARGET, "[Diagnostics] ignoring 'P2pServiceQuery::GetChain'"),
+                        debug!(target: LOG_TARGET, "[Diagnostics] ignoring 'P2pServiceQuery::GetChain'"),
                         Some(req) => self.handle_query(req).await,
                         None =>
                             warn!(
@@ -3203,22 +3269,25 @@ where S: ShareChain
                     }
                 },
                 _inner_req = self.inner_request_rx.recv() => {
-                    warn!(target: LOG_TARGET, "[Diagnostics] Ignoring inner request");
+                    debug!(target: LOG_TARGET, "[Diagnostics] Ignoring inner request");
                 }
                 _blocks = self.client_broadcast_block_rx.recv() => {
-                    warn!(target: LOG_TARGET, "[Diagnostics] Ignoring broadcast blocks");
+                    debug!(target: LOG_TARGET, "[Diagnostics] Ignoring broadcast blocks");
                 },
                 event = self.swarm.select_next_some() => {
                     let timer = Instant::now();
                     match event {
                         SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::MetaDataExchange(_) ) => {
-                            warn!(target: LOG_TARGET, "[Diagnostics] Ignoring MetaDataExchange events");
+                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring MetaDataExchange events");
                         },
                         SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::ShareChainSync(_)) => {
-                            warn!(target: LOG_TARGET, "[Diagnostics] Ignoring ShareChainSync events");
+                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring ShareChainSync events");
                         },
                         SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::CatchUpSync(_)) => {
-                            warn!(target: LOG_TARGET, "[Diagnostics] Ignoring CatchUpSync events");
+                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring CatchUpSync events");
+                        },
+                        SwarmEvent::Behaviour(ServerNetworkBehaviourEvent::Gossipsub(_)) => {
+                            debug!(target: LOG_TARGET, "[Diagnostics] Ignoring Gossipsub events");
                         },
                         _ => self.handle_event(event).await,
                     }
@@ -3417,8 +3486,15 @@ where S: ShareChain
 
     pub async fn dial_seed_peers(&mut self) -> Result<(), Error> {
         info!(target: LOG_TARGET, "Dialing seed peers...");
-        let seed_peers = self.parse_seed_peers().await?;
-        self.join_seed_peers(seed_peers).await;
+        match self.parse_seed_peers().await {
+            Ok(seed_peers) => {
+                self.join_seed_peers(seed_peers).await;
+            },
+            Err(e) => {
+                warn!(target: LOG_TARGET, "Failed to parse seed peers: {e:?}");
+                return Err(e);
+            },
+        }
         Ok(())
     }
 
@@ -3450,12 +3526,21 @@ where S: ShareChain
         self.subscribe_to_topics().await;
 
         if self.config.diagnostic_mode {
-            debug!(target: LOG_TARGET, "Starting diagnostic loop");
-            self.main_loop_diagnostic_mode().await?;
+            debug!(target: LOG_TARGET, "Starting main loop diagnostic mode");
+            if let Err(e) = self.main_loop_diagnostic_mode().await {
+                warn!(target: LOG_TARGET, "Diagnostic loop failed: {e:?}");
+                return Err(e);
+            }
         } else {
-            self.dial_seed_peers().await?;
-            debug!(target: LOG_TARGET, "Starting main loop");
-            self.main_loop().await?;
+            if let Err(e) = self.dial_seed_peers().await {
+                warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
+                return Err(e);
+            }
+            debug!(target: LOG_TARGET, "Starting main loop normal mode");
+            if let Err(e) = self.main_loop().await {
+                warn!(target: LOG_TARGET, "Main loop failed: {e:?}");
+                return Err(e);
+            }
         }
         info!(target: LOG_TARGET,"P2P service has been stopped!");
         Ok(())

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -3185,8 +3185,8 @@ where S: ShareChain
 
                             let diagnostics_data = [
                                 ("seeds", json!({ "seeds": seeds_data })),
-                                ("privates", json!({ "privates": private_peers_data })),
-                                ("relays", json!({ "relays": relays_data }))
+                                ("relays", json!({ "relays": relays_data })),
+                                ("private peers", json!({ "private peers": private_peers_data })),
                             ];
                             let local_node = ("local_node", json!(
                                 {"local_node":
@@ -3199,18 +3199,24 @@ where S: ShareChain
                             let summary = ("summary", json!(
                                 {
                                     "summary": {
-                                        "Connect to each DNS seeds":
+                                        "1. Connect to DNS seeds             :":
                                             seeds_data.iter().any(|peer| peer.dial_succeeded),
-                                        "Download peers from the DNS seeds":
+                                        "2. Download peers from DNS seeds    :":
                                             seeds_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
-                                        "Connect to 5 of private peers":
-                                            private_peers_data.iter().any(|peer| peer.dial_succeeded),
-                                        "Download peers from private seeds":
-                                            private_peers_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
-                                        "Connect to 5 of relay peers":
+                                        "3. Number of DNS seeds responded    :":
+                                            seeds_data.iter().filter(|peer| peer.response_time.is_some()).count(),
+                                        "4. Connect to relay peers           :":
                                             relays_data.iter().any(|peer| peer.dial_succeeded),
-                                        "Download peers from relay seeds":
-                                            relays_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0)
+                                        "5. Download peers from relay peers  :":
+                                            relays_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
+                                        "6. Number of relay peers responded  :":
+                                            relays_data.iter().filter(|peer| peer.response_time.is_some()).count(),
+                                        "7. Connect to private peers         :":
+                                            private_peers_data.iter().any(|peer| peer.dial_succeeded),
+                                        "8. Download peers from private peers:":
+                                            private_peers_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
+                                        "9. Number of private peers responded:":
+                                            private_peers_data.iter().filter(|peer| peer.response_time.is_some()).count(),
                                     }
                                 })
                             );
@@ -3244,6 +3250,13 @@ where S: ShareChain
                                     }
                                     let _unused = writeln!(&file);
                                 }
+                            }
+                            else {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[Diagnostics] Failed to create diagnostics file at path: {:?}",
+                                    file_path
+                                );
                             }
                             info!(target: LOG_TARGET, "Diagnostics written to file: {}", file_path.display());
 

--- a/p2pool/src/server/server.rs
+++ b/p2pool/src/server/server.rs
@@ -13,7 +13,7 @@ use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use tari_common::configuration::Network;
 use tari_core::{consensus::ConsensusManager, proof_of_work::randomx_factory::RandomXFactory};
-use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_shutdown::Shutdown;
 
 use super::http::stats_collector::{StatsBroadcastClient, StatsCollector};
 use crate::{
@@ -91,7 +91,7 @@ where S: ShareChain
         let genesis_block_hash = *consensus_manager.get_genesis_block().hash();
         if !config.p2p_service.is_seed_peer {
             let base_node_grpc_service =
-                TariBaseNodeGrpc::new(config.base_node_address.clone(), shutdown.to_signal().clone()).await?;
+                TariBaseNodeGrpc::new(config.base_node_address.clone(), shutdown.clone()).await?;
             base_node_grpc_server = Some(BaseNodeServer::new(base_node_grpc_service));
 
             let p2pool_grpc_service = ShaP2PoolGrpc::new(
@@ -118,7 +118,7 @@ where S: ShareChain
                 stats_client,
                 config.http_server.port,
                 query_client,
-                shutdown.to_signal().clone(),
+                shutdown.clone(),
             )))
         } else {
             None
@@ -142,10 +142,11 @@ where S: ShareChain
         base_node_service: BaseNodeServer<TariBaseNodeGrpc>,
         p2pool_service: ShaP2PoolServer<ShaP2PoolGrpc<S>>,
         grpc_port: u16,
-        shutdown_signal: ShutdownSignal,
+        shutdown: Shutdown,
     ) -> Result<(), Error> {
         info!(target: LOG_TARGET, "Starting gRPC server on port {}!", &grpc_port);
 
+        let shutdown_signal = shutdown.to_signal();
         tonic::transport::Server::builder()
             .add_service(base_node_service)
             .add_service(p2pool_service)
@@ -179,10 +180,10 @@ where S: ShareChain
             let base_node_grpc_service = self.base_node_grpc_service.clone().unwrap();
             let p2pool_grpc_service = self.p2pool_grpc_service.clone().unwrap();
             let grpc_port = self.config.grpc_port;
-            let shutdown_signal = self.shutdown.to_signal().clone();
+            let shutdown = self.shutdown.clone();
             tokio::spawn(async move {
                 if let Err(error) =
-                    Self::start_grpc(base_node_grpc_service, p2pool_grpc_service, grpc_port, shutdown_signal).await
+                    Self::start_grpc(base_node_grpc_service, p2pool_grpc_service, grpc_port, shutdown).await
                 {
                     error!(target: LOG_TARGET, "GRPC Server encountered an error: {:?}", error);
                 }

--- a/p2pool/src/server/server.rs
+++ b/p2pool/src/server/server.rs
@@ -13,12 +13,13 @@ use log::{error, info};
 use minotari_app_grpc::tari_rpc::{base_node_server::BaseNodeServer, sha_p2_pool_server::ShaP2PoolServer};
 use tari_common::configuration::Network;
 use tari_core::{consensus::ConsensusManager, proof_of_work::randomx_factory::RandomXFactory};
-use tari_shutdown::ShutdownSignal;
+use tari_shutdown::{Shutdown, ShutdownSignal};
 
 use super::http::stats_collector::{StatsBroadcastClient, StatsCollector};
 use crate::{
     server::{
         config,
+        diagnostics::{DiagnosticsBroadcastClient, DiagnosticsCollector, DiagnosticsReceiverClient},
         grpc::{base_node::TariBaseNodeGrpc, p2pool::ShaP2PoolGrpc},
         http::server::HttpServer,
         p2p,
@@ -39,7 +40,8 @@ where S: ShareChain
     p2pool_grpc_service: Option<ShaP2PoolServer<ShaP2PoolGrpc<S>>>,
     http_server: Option<Arc<HttpServer>>,
     stats_collector: Option<StatsCollector>,
-    shutdown_signal: ShutdownSignal,
+    diagnostics_collector: Option<DiagnosticsCollector>,
+    shutdown: Shutdown,
     are_we_synced_with_randomx_p2pool: Arc<AtomicBool>,
     are_we_synced_with_sha3x_p2pool: Arc<AtomicBool>,
 }
@@ -53,7 +55,10 @@ where S: ShareChain
         share_chain_random_x: S,
         stats_collector: StatsCollector,
         stats_broadcast_client: StatsBroadcastClient,
-        shutdown_signal: ShutdownSignal,
+        diagnostics_collector: Option<DiagnosticsCollector>,
+        diagnostics_broadcast_client: Option<DiagnosticsBroadcastClient>,
+        diagnostics_receiver_client: Option<DiagnosticsReceiverClient>,
+        shutdown: Shutdown,
         swarm: Swarm<ServerNetworkBehaviour>,
         squad: String,
     ) -> Result<Self, Error> {
@@ -66,10 +71,12 @@ where S: ShareChain
             &config,
             share_chain_sha3x.clone(),
             share_chain_random_x.clone(),
-            shutdown_signal.clone(),
+            shutdown.clone(),
             are_we_synced_with_randomx_p2pool.clone(),
             are_we_synced_with_sha3x_p2pool.clone(),
             stats_broadcast_client.clone(),
+            diagnostics_broadcast_client,
+            diagnostics_receiver_client,
             config.share_window,
             swarm,
             squad.clone(),
@@ -84,7 +91,7 @@ where S: ShareChain
         let genesis_block_hash = *consensus_manager.get_genesis_block().hash();
         if !config.p2p_service.is_seed_peer {
             let base_node_grpc_service =
-                TariBaseNodeGrpc::new(config.base_node_address.clone(), shutdown_signal.clone()).await?;
+                TariBaseNodeGrpc::new(config.base_node_address.clone(), shutdown.to_signal().clone()).await?;
             base_node_grpc_server = Some(BaseNodeServer::new(base_node_grpc_service));
 
             let p2pool_grpc_service = ShaP2PoolGrpc::new(
@@ -111,7 +118,7 @@ where S: ShareChain
                 stats_client,
                 config.http_server.port,
                 query_client,
-                shutdown_signal.clone(),
+                shutdown.to_signal().clone(),
             )))
         } else {
             None
@@ -124,7 +131,8 @@ where S: ShareChain
             p2pool_grpc_service: p2pool_server,
             http_server,
             stats_collector: Some(stats_collector),
-            shutdown_signal,
+            diagnostics_collector,
+            shutdown,
             are_we_synced_with_randomx_p2pool,
             are_we_synced_with_sha3x_p2pool,
         })
@@ -171,7 +179,7 @@ where S: ShareChain
             let base_node_grpc_service = self.base_node_grpc_service.clone().unwrap();
             let p2pool_grpc_service = self.p2pool_grpc_service.clone().unwrap();
             let grpc_port = self.config.grpc_port;
-            let shutdown_signal = self.shutdown_signal.clone();
+            let shutdown_signal = self.shutdown.to_signal().clone();
             tokio::spawn(async move {
                 if let Err(error) =
                     Self::start_grpc(base_node_grpc_service, p2pool_grpc_service, grpc_port, shutdown_signal).await
@@ -190,6 +198,17 @@ where S: ShareChain
                 }
 
                 info!(target: LOG_TARGET, "Stats collector stopped!");
+            });
+        }
+
+        let diagnostics_server = self.diagnostics_collector.take();
+        if let Some(mut server) = diagnostics_server {
+            tokio::spawn(async move {
+                if let Err(err) = server.run().await {
+                    error!(target: LOG_TARGET, "Diagnostics collector encountered an error: {:?}", err);
+                }
+
+                info!(target: LOG_TARGET, "Diagnostics collector stopped!");
             });
         }
 


### PR DESCRIPTION
Description
---
Added a command-line option (`--diagnostic-mode` with optional `--diagnostic-mode-file-path`) to perform various diagnostics upon startup. Diagnostics will be collected and written to a file (`diagnostic_results.json`), and when done the node will exit.

Closes #257

Motivation and Context
---
See #257

How Has This Been Tested?
---
New cucumber test: `Scenario: I run a diagnostic node to learn about the network connections`
A sample diagnostics result file is shown below;
```json
{
  "local_node": {
    "peer_id": "12D3KooWLdEx863jgJMgcTzh8V3fEDiTZ4gtKgZimRSEZUjt9r9F",
    "public_addresses": [
      "/ip4/127.0.0.1/udp/18239/quic-v1"
    ]
  }
}
{
  "summary": {
    "1. Connect to DNS seeds             _": true,
    "2. Download peers from DNS seeds    _": true,
    "3. Number of DNS seeds responded    _": 3,
    "4. Connect to relay peers           _": true,
    "5. Download peers from relay peers  _": false,
    "6. Number of relay peers responded  _": 5,
    "7. Connect to private peers         _": false,
    "8. Download peers from private peers_": false,
    "9. Number of private peers responded_": 0
  }
}
{
  "seeds": [
    {
      "connected_at": "2025-03-17T11:02:23+02:00",
      "dial_succeeded": true,
      "dial_time": 0.0,
      "number_of_peers": 10,
      "peer_id": "12D3KooWHHcCmoEu9b2dZsdmgxd4D7Zvh9dnbdthTW8aSuUbgpnY",
      "requested_peers_at": "2025-03-17T11:02:23+02:00",
      "response_time": 0.0
    },
    {
      "connected_at": "2025-03-17T11:02:23+02:00",
      "dial_succeeded": true,
      "dial_time": 0.0,
      "number_of_peers": 9,
      "peer_id": "12D3KooWNRbqhWgCZvjTqa9A8mcfRjwETCXUaR7uthGMEYieaFDw",
      "requested_peers_at": "2025-03-17T11:02:23+02:00",
      "response_time": 0.0
    },
    {
      "connected_at": "2025-03-17T11:02:23+02:00",
      "dial_succeeded": true,
      "dial_time": 0.0,
      "number_of_peers": 8,
      "peer_id": "12D3KooWDVbc4t6kvWjWSLWj1QknxUeaTPmscFvquRHcPttKu8s3",
      "requested_peers_at": "2025-03-17T11:02:23+02:00",
      "response_time": 0.0
    }
  ]
}
{
  "relays": [
    {
      "connected_at": "2025-03-17T11:02:25+02:00",
      "dial_succeeded": true,
      "dial_time": 0.0,
      "number_of_peers": 0,
      "peer_id": "12D3KooWMfDYmUFv3bsbXgEeGn1vrRLyFcKDEDarMkm7aVF9oGTu",
      "requested_peers_at": "2025-03-17T11:02:25+02:00",
      "response_time": 0.0
    },
    {
      "connected_at": "2025-03-17T11:02:25+02:00",
      "dial_succeeded": true,
      "dial_time": 0.0,
      "number_of_peers": 0,
      "peer_id": "12D3KooWE4uQScTJJwJ8yFidLA4paHQR54Ain33NyrsNxdniYTbz",
      "requested_peers_at": "2025-03-17T11:02:25+02:00",
      "response_time": 0.0
    },
    {
      "connected_at": "2025-03-17T11:02:25+02:00",
      "dial_succeeded": true,
      "dial_time": 0.004,
      "number_of_peers": 0,
      "peer_id": "12D3KooWHCe7heq9PsZuFDU1iM7AvvpXva4DdA4qXNXYbXKhaMMN",
      "requested_peers_at": "2025-03-17T11:02:25+02:00",
      "response_time": 0.0
    },
    {
      "connected_at": "2025-03-17T11:02:25+02:00",
      "dial_succeeded": true,
      "dial_time": 0.0,
      "number_of_peers": 0,
      "peer_id": "12D3KooWFXW8YME6MKafTQP9GARLtDBmYnxWyYbP6Qwte8beAVF9",
      "requested_peers_at": "2025-03-17T11:02:25+02:00",
      "response_time": 0.0
    },
    {
      "connected_at": "2025-03-17T11:02:25+02:00",
      "dial_succeeded": true,
      "dial_time": 0.001,
      "number_of_peers": 0,
      "peer_id": "12D3KooWLJB5YEqx2SbbVwhun5VTo9bcrpWakyANFjTuSm4THPXL",
      "requested_peers_at": "2025-03-17T11:02:25+02:00",
      "response_time": 0.0
    }
  ]
}
{
  "private peers": []
}
```

What process can a PR reviewer use to test or verify this change?
---
Code review
Run the cucumber test

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a diagnostic mode that adjusts node operations to support enhanced visibility into connectivity and performance.
  - Added new command-line options and a dedicated diagnostics command, making it easier for users to launch nodes in this mode and collect relevant operational data.
  - Enhanced peer-to-peer network service with diagnostics capabilities, including data collection and reporting.
  - Added new scenarios in integration tests to validate the functionality of diagnostic nodes.

- **Bug Fixes**
  - Improved error handling for diagnostic operations, ensuring better logging and response management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->