### PR TITLE
feat: improve diagnostics

### DIFF
--- a/p2pool/src/server/diagnostics/diagnostics_collector.rs
+++ b/p2pool/src/server/diagnostics/diagnostics_collector.rs
@@ -1,62 +1,51 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, fmt::Debug, time::Duration};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt::Debug,
+    time::{Duration, SystemTime},
+};
 
 use libp2p::PeerId;
 use log::*;
 use serde::Serialize;
 use tari_shutdown::Shutdown;
-use tari_utilities::epoch_time::EpochTime;
 use tokio::{
     sync::{broadcast::Receiver, oneshot},
     time::MissedTickBehavior,
 };
 
+use crate::server::PeerType;
+
 #[derive(Serialize, Clone, Debug)]
 pub struct DiagnosticPeerInfo {
     pub peer_id: PeerId,
-    #[serde(with = "duration_as_seconds")]
-    pub dial_time: Duration,
-    pub dial_succeeded: bool,
-    #[serde(with = "epoch_time_as_rfc3339")]
-    pub connected_at: Option<EpochTime>,
-    #[serde(with = "epoch_time_as_rfc3339")]
-    pub requested_peers_at: Option<EpochTime>,
+    #[serde(with = "format_time")]
+    pub connected_at: Option<SystemTime>,
+    #[serde(with = "format_time")]
+    pub requested_peers_at: Option<SystemTime>,
     pub number_of_peers: Option<usize>,
-    #[serde(with = "duration_option_as_seconds")]
+    #[serde(rename = "response_time (s)", with = "duration_option_as_seconds")]
     pub response_time: Option<Duration>,
 }
 
-mod epoch_time_as_rfc3339 {
-    use chrono::{Local, TimeZone};
+mod format_time {
+    use std::time::SystemTime;
+
+    use chrono::{DateTime, Local};
     use serde::Serializer;
 
-    use super::*;
-
-    pub fn serialize<S>(time: &Option<EpochTime>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(time: &Option<SystemTime>, serializer: S) -> Result<S::Ok, S::Error>
     where S: Serializer {
         match time {
             Some(t) => {
-                let dt = Local
-                    .timestamp_opt(i64::try_from(t.as_u64()).unwrap_or_default(), 0)
-                    .single()
-                    .unwrap_or_default();
-                serializer.serialize_some(&dt.to_rfc3339())
+                let datetime: DateTime<Local> = DateTime::from(*t);
+                let dt = datetime.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+                serializer.serialize_some(&dt)
             },
             None => serializer.serialize_none(),
         }
-    }
-}
-
-mod duration_as_seconds {
-    use std::time::Duration;
-
-    use serde::Serializer;
-
-    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
-        serializer.serialize_some(&(duration.as_secs() as f64 + f64::from(duration.subsec_millis()) * 1e-3))
     }
 }
 
@@ -68,7 +57,11 @@ mod duration_option_as_seconds {
     pub fn serialize<S>(duration: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
     where S: Serializer {
         match duration {
-            Some(d) => serializer.serialize_some(&(d.as_secs() as f64 + f64::from(d.subsec_millis()) * 1e-3)),
+            Some(d) => {
+                let seconds = d.as_secs() as f64 + f64::from(d.subsec_millis()) * 1e-3;
+                let formatted = format!("{:.3}", seconds);
+                serializer.serialize_some(&formatted)
+            },
             None => serializer.serialize_none(),
         }
     }
@@ -80,10 +73,12 @@ pub struct DiagnosticsCollector {
     broadcast_receiver: tokio::sync::broadcast::Receiver<DiagnosticData>,
     request_tx: tokio::sync::mpsc::Sender<DiagnosticRequest>,
     request_rx: tokio::sync::mpsc::Receiver<DiagnosticRequest>,
-    first_data_received: Option<EpochTime>,
+    first_data_received: Option<SystemTime>,
     seed_peer_info: HashMap<String, DiagnosticPeerInfo>,
     private_peer_info: HashMap<String, DiagnosticPeerInfo>,
     relay_peer_info: HashMap<String, DiagnosticPeerInfo>,
+    non_squad_peer_info: HashMap<String, DiagnosticPeerInfo>,
+    unknown_peer_info: HashMap<String, DiagnosticPeerInfo>,
 }
 
 impl DiagnosticsCollector {
@@ -98,6 +93,8 @@ impl DiagnosticsCollector {
             seed_peer_info: HashMap::new(),
             private_peer_info: HashMap::new(),
             relay_peer_info: HashMap::new(),
+            non_squad_peer_info: HashMap::new(),
+            unknown_peer_info: HashMap::new(),
         }
     }
 
@@ -107,110 +104,235 @@ impl DiagnosticsCollector {
         }
     }
 
+    fn hydrate_and_get_existing(&mut self, peer_id: PeerId, peer_type: PeerType) -> Option<&mut DiagnosticPeerInfo> {
+        let peer_id_base58 = peer_id.to_base58();
+        // The peer type could have changed form Unknown to SeedPeer, PrivatePeer or RelayPeer, etc. Move the peer
+        // to the correct peer type
+        let hydrate_peer = if self.unknown_peer_info.contains_key(&peer_id_base58) {
+            if peer_type == PeerType::Unknown {
+                None
+            } else {
+                self.unknown_peer_info.remove(&peer_id_base58)
+            }
+        } else if self.private_peer_info.contains_key(&peer_id_base58) {
+            if peer_type == PeerType::PrivatePeer {
+                None
+            } else {
+                self.private_peer_info.remove(&peer_id_base58)
+            }
+        } else if self.seed_peer_info.contains_key(&peer_id_base58) {
+            if peer_type == PeerType::SeedPeer {
+                None
+            } else {
+                self.seed_peer_info.remove(&peer_id_base58)
+            }
+        } else if self.relay_peer_info.contains_key(&peer_id_base58) {
+            if peer_type == PeerType::RelayPeer {
+                None
+            } else {
+                self.relay_peer_info.remove(&peer_id_base58)
+            }
+        } else if self.non_squad_peer_info.contains_key(&peer_id_base58) {
+            if peer_type == PeerType::NonSquadPeer {
+                None
+            } else {
+                self.non_squad_peer_info.remove(&peer_id_base58)
+            }
+        } else {
+            None
+        };
+
+        // Hydrate
+        if let Some(peer) = hydrate_peer {
+            match peer_type {
+                PeerType::SeedPeer => {
+                    self.seed_peer_info.insert(peer_id_base58, peer.clone());
+                },
+                PeerType::PrivatePeer => {
+                    self.private_peer_info.insert(peer_id_base58, peer.clone());
+                },
+                PeerType::RelayPeer => {
+                    self.relay_peer_info.insert(peer_id_base58, peer.clone());
+                },
+                PeerType::NonSquadPeer => {
+                    self.non_squad_peer_info.insert(peer_id_base58, peer.clone());
+                },
+                PeerType::Unknown => {
+                    self.unknown_peer_info.insert(peer_id_base58, peer.clone());
+                },
+            }
+        }
+
+        // Now we can get the peer info
+        let peer_id_base58 = peer_id.to_base58();
+        let peer_info = self
+            .private_peer_info
+            .get_mut(&peer_id_base58)
+            .or_else(|| self.seed_peer_info.get_mut(&peer_id_base58))
+            .or_else(|| self.relay_peer_info.get_mut(&peer_id_base58))
+            .or_else(|| self.non_squad_peer_info.get_mut(&peer_id_base58))
+            .or_else(|| self.unknown_peer_info.get_mut(&peer_id_base58));
+        peer_info
+    }
+
     #[allow(clippy::too_many_lines)]
     fn handle_diagnostic(&mut self, data: DiagnosticData) {
-        debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
         match data {
-            DiagnosticData::NewSeedPeer {
-                peer_id,
-                dial_time,
-                dial_succeeded,
-                ..
-            } => {
-                self.seed_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
-                    peer_id,
-                    dial_time,
-                    dial_succeeded,
-                    connected_at: None,
-                    requested_peers_at: None,
-                    number_of_peers: None,
-                    response_time: None,
-                });
-            },
-            DiagnosticData::NewPrivatePeer {
-                peer_id,
-                dial_time,
-                dial_succeeded,
-                ..
-            } => {
-                self.private_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
-                    peer_id,
-                    dial_time,
-                    dial_succeeded,
-                    connected_at: None,
-                    requested_peers_at: None,
-                    number_of_peers: None,
-                    response_time: None,
-                });
-            },
-            DiagnosticData::NewRelayPeer {
-                peer_id,
-                dial_time,
-                dial_succeeded,
-                ..
-            } => {
-                self.relay_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
-                    peer_id,
-                    dial_time,
-                    dial_succeeded,
-                    connected_at: None,
-                    requested_peers_at: None,
-                    number_of_peers: None,
-                    response_time: None,
-                });
-            },
-            DiagnosticData::PeerRequest { peer_id, .. } => {
-                let existing_peer = self
-                    .private_peer_info
-                    .get_mut(&peer_id.to_base58())
-                    .or_else(|| self.seed_peer_info.get_mut(&peer_id.to_base58()))
-                    .or_else(|| self.relay_peer_info.get_mut(&peer_id.to_base58()));
-                if let Some(peer) = existing_peer {
-                    if peer.requested_peers_at.is_none() {
-                        peer.requested_peers_at = Some(EpochTime::now());
-                    }
+            DiagnosticData::NewSeedPeer { peer_id, .. } => {
+                if let Entry::Vacant(entry) = self.seed_peer_info.entry(peer_id.to_base58()) {
+                    entry.insert(DiagnosticPeerInfo {
+                        peer_id,
+                        connected_at: None,
+                        requested_peers_at: None,
+                        number_of_peers: None,
+                        response_time: None,
+                    });
+                    debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
                 }
             },
-            DiagnosticData::PeerConnected { peer_id, .. } => {
-                let existing_peer = self
-                    .private_peer_info
-                    .get_mut(&peer_id.to_base58())
-                    .or_else(|| self.seed_peer_info.get_mut(&peer_id.to_base58()))
-                    .or_else(|| self.relay_peer_info.get_mut(&peer_id.to_base58()));
+            DiagnosticData::NewPrivatePeer { peer_id, .. } => {
+                if let Entry::Vacant(entry) = self.private_peer_info.entry(peer_id.to_base58()) {
+                    entry.insert(DiagnosticPeerInfo {
+                        peer_id,
+                        connected_at: None,
+                        requested_peers_at: None,
+                        number_of_peers: None,
+                        response_time: None,
+                    });
+                    debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
+                }
+            },
+            DiagnosticData::NewRelayPeer { peer_id, .. } => {
+                if let Entry::Vacant(entry) = self.relay_peer_info.entry(peer_id.to_base58()) {
+                    entry.insert(DiagnosticPeerInfo {
+                        peer_id,
+                        connected_at: None,
+                        requested_peers_at: None,
+                        number_of_peers: None,
+                        response_time: None,
+                    });
+                    debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
+                }
+            },
+            DiagnosticData::NewNonSquadPeer { peer_id, .. } => {
+                if let Entry::Vacant(entry) = self.non_squad_peer_info.entry(peer_id.to_base58()) {
+                    entry.insert(DiagnosticPeerInfo {
+                        peer_id,
+                        connected_at: None,
+                        requested_peers_at: None,
+                        number_of_peers: None,
+                        response_time: None,
+                    });
+                    debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
+                }
+            },
+            DiagnosticData::NewUnknownPeer { peer_id, .. } => {
+                if let Entry::Vacant(entry) = self.unknown_peer_info.entry(peer_id.to_base58()) {
+                    entry.insert(DiagnosticPeerInfo {
+                        peer_id,
+                        connected_at: None,
+                        requested_peers_at: None,
+                        number_of_peers: None,
+                        response_time: None,
+                    });
+                    debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {data:?}");
+                }
+            },
+            DiagnosticData::PeerConnected {
+                peer_id, ref peer_type, ..
+            } => {
+                let existing_peer = self.hydrate_and_get_existing(peer_id, *peer_type);
                 if let Some(peer) = existing_peer {
                     if peer.connected_at.is_none() {
-                        peer.connected_at = Some(EpochTime::now());
+                        peer.connected_at = Some(SystemTime::now());
                     }
+                } else {
+                    match peer_type {
+                        PeerType::SeedPeer => {
+                            self.seed_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                                peer_id,
+                                connected_at: Some(SystemTime::now()),
+                                requested_peers_at: None,
+                                number_of_peers: None,
+                                response_time: None,
+                            });
+                        },
+                        PeerType::PrivatePeer => {
+                            self.private_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                                peer_id,
+                                connected_at: Some(SystemTime::now()),
+                                requested_peers_at: None,
+                                number_of_peers: None,
+                                response_time: None,
+                            });
+                        },
+                        PeerType::RelayPeer => {
+                            self.relay_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                                peer_id,
+                                connected_at: Some(SystemTime::now()),
+                                requested_peers_at: None,
+                                number_of_peers: None,
+                                response_time: None,
+                            });
+                        },
+                        PeerType::NonSquadPeer => {
+                            self.non_squad_peer_info
+                                .insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                                    peer_id,
+                                    connected_at: Some(SystemTime::now()),
+                                    requested_peers_at: None,
+                                    number_of_peers: None,
+                                    response_time: None,
+                                });
+                        },
+                        PeerType::Unknown => {
+                            self.unknown_peer_info.insert(peer_id.to_base58(), DiagnosticPeerInfo {
+                                peer_id,
+                                connected_at: Some(SystemTime::now()),
+                                requested_peers_at: None,
+                                number_of_peers: None,
+                                response_time: None,
+                            });
+                        },
+                    }
+                }
+                debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {peer_type} {data:?}");
+            },
+            DiagnosticData::PeerRequest {
+                peer_id, ref peer_type, ..
+            } => {
+                let existing_peer = self.hydrate_and_get_existing(peer_id, *peer_type);
+                if let Some(peer) = existing_peer {
+                    if peer.requested_peers_at.is_none() {
+                        peer.requested_peers_at = Some(SystemTime::now());
+                        debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {peer_type} {data:?}");
+                    }
+                } else {
+                    warn!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {peer_type} {peer_id} not found");
                 }
             },
             DiagnosticData::PeerResponse {
                 peer_id,
+                ref peer_type,
                 number_of_peers,
                 ..
             } => {
-                let existing_peer = self
-                    .private_peer_info
-                    .get_mut(&peer_id.to_base58())
-                    .or_else(|| self.seed_peer_info.get_mut(&peer_id.to_base58()))
-                    .or_else(|| self.relay_peer_info.get_mut(&peer_id.to_base58()));
+                let existing_peer = self.hydrate_and_get_existing(peer_id, *peer_type);
                 if let Some(peer) = existing_peer {
-                    if let Some(number) = peer.number_of_peers {
-                        if number_of_peers > number {
-                            peer.number_of_peers = Some(number_of_peers);
-                            peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
-                                EpochTime::now()
-                                    .checked_sub(requested_peers_at)
-                                    .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
-                            });
-                        }
+                    let new_total = if let Some(number) = peer.number_of_peers {
+                        number_of_peers + number
                     } else {
-                        peer.number_of_peers = Some(number_of_peers);
-                        peer.response_time = peer.requested_peers_at.and_then(|requested_peers_at| {
-                            EpochTime::now()
-                                .checked_sub(requested_peers_at)
-                                .map(|epoch_time| Duration::from_secs(epoch_time.as_u64()))
+                        number_of_peers
+                    };
+                    peer.number_of_peers = Some(new_total);
+                    if peer.response_time.is_none() {
+                        peer.response_time = peer.requested_peers_at.map(|requested_peers_at| {
+                            SystemTime::now().duration_since(requested_peers_at).unwrap_or_default()
                         });
                     }
+                    debug!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {peer_type} {data:?}");
+                } else {
+                    warn!(target: LOG_TARGET, "[Diagnostics] handle diagnostics {peer_type} {peer_id} not found");
                 }
             },
         }
@@ -230,10 +352,13 @@ impl DiagnosticsCollector {
                 _ = diagnostics_report_timer.tick() => {
                     info!(
                         target: LOG_TARGET,
-                        "========= Uptime: {}. Seeds: {}, Peers: {}, Relay peers: {} ==== ",
-                        humantime::format_duration(Duration::from_secs(EpochTime::now().as_u64().checked_sub(
-                            self.first_data_received.unwrap_or(EpochTime::now()).as_u64()
-                        ).unwrap_or_default())),
+                        "========= Uptime: {:?}. Seeds: {}, Peers: {}, Relay peers: {} ==== ",
+                        Duration::from_secs(
+                            SystemTime::now()
+                                .duration_since(self.first_data_received.unwrap_or(SystemTime::now()))
+                                .unwrap_or_default()
+                                .as_secs()
+                        ),
                         self.seed_peer_info.len(),
                         self.private_peer_info.len(),
                         self.relay_peer_info.len(),
@@ -298,39 +423,44 @@ impl DiagnosticsCollector {
 pub(crate) enum DiagnosticData {
     NewSeedPeer {
         peer_id: PeerId,
-        dial_time: Duration,
-        dial_succeeded: bool,
-        timestamp: EpochTime,
+        timestamp: SystemTime,
     },
     NewPrivatePeer {
         peer_id: PeerId,
-        dial_time: Duration,
-        dial_succeeded: bool,
-        timestamp: EpochTime,
+        timestamp: SystemTime,
     },
     NewRelayPeer {
         peer_id: PeerId,
-        dial_time: Duration,
-        dial_succeeded: bool,
-        timestamp: EpochTime,
+        timestamp: SystemTime,
     },
-    PeerRequest {
+    NewNonSquadPeer {
         peer_id: PeerId,
-        timestamp: EpochTime,
+        timestamp: SystemTime,
     },
-    PeerResponse {
+    NewUnknownPeer {
         peer_id: PeerId,
-        number_of_peers: usize,
-        timestamp: EpochTime,
+        timestamp: SystemTime,
     },
     PeerConnected {
         peer_id: PeerId,
-        timestamp: EpochTime,
+        peer_type: PeerType,
+        timestamp: SystemTime,
+    },
+    PeerRequest {
+        peer_id: PeerId,
+        peer_type: PeerType,
+        timestamp: SystemTime,
+    },
+    PeerResponse {
+        peer_id: PeerId,
+        peer_type: PeerType,
+        number_of_peers: usize,
+        timestamp: SystemTime,
     },
 }
 
 impl DiagnosticData {
-    pub fn timestamp(&self) -> EpochTime {
+    pub fn timestamp(&self) -> SystemTime {
         match self {
             DiagnosticData::NewSeedPeer { timestamp, .. } => *timestamp,
             DiagnosticData::NewPrivatePeer { timestamp, .. } => *timestamp,
@@ -338,6 +468,8 @@ impl DiagnosticData {
             DiagnosticData::PeerRequest { timestamp, .. } => *timestamp,
             DiagnosticData::PeerResponse { timestamp, .. } => *timestamp,
             DiagnosticData::PeerConnected { timestamp, .. } => *timestamp,
+            DiagnosticData::NewNonSquadPeer { timestamp, .. } => *timestamp,
+            DiagnosticData::NewUnknownPeer { timestamp, .. } => *timestamp,
         }
     }
 }
@@ -399,67 +531,58 @@ impl DiagnosticsBroadcastClient {
         Ok(())
     }
 
-    pub fn send_new_seed_peer(
-        &self,
-        peer_id: PeerId,
-        dial_time: Duration,
-        dial_succeeded: bool,
-    ) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::NewSeedPeer {
-            peer_id,
-            dial_time,
-            dial_succeeded,
-            timestamp: EpochTime::now(),
-        })
+    pub fn send_new_peer(&self, peer_id: PeerId, peer_type: PeerType) -> Result<(), anyhow::Error> {
+        match peer_type {
+            PeerType::SeedPeer => self.broadcast(DiagnosticData::NewSeedPeer {
+                peer_id,
+                timestamp: SystemTime::now(),
+            }),
+            PeerType::PrivatePeer => self.broadcast(DiagnosticData::NewPrivatePeer {
+                peer_id,
+                timestamp: SystemTime::now(),
+            }),
+            PeerType::RelayPeer => self.broadcast(DiagnosticData::NewRelayPeer {
+                peer_id,
+                timestamp: SystemTime::now(),
+            }),
+            PeerType::NonSquadPeer => self.broadcast(DiagnosticData::NewNonSquadPeer {
+                peer_id,
+                timestamp: SystemTime::now(),
+            }),
+            PeerType::Unknown => self.broadcast(DiagnosticData::NewUnknownPeer {
+                peer_id,
+                timestamp: SystemTime::now(),
+            }),
+        }
     }
 
-    pub fn send_new_private_peer(
-        &self,
-        peer_id: PeerId,
-        dial_time: Duration,
-        dial_succeeded: bool,
-    ) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::NewPrivatePeer {
-            peer_id,
-            timestamp: EpochTime::now(),
-            dial_time,
-            dial_succeeded,
-        })
-    }
-
-    pub fn send_new_relay_peer(
-        &self,
-        peer_id: PeerId,
-        dial_time: Duration,
-        dial_succeeded: bool,
-    ) -> Result<(), anyhow::Error> {
-        self.broadcast(DiagnosticData::NewRelayPeer {
-            peer_id,
-            timestamp: EpochTime::now(),
-            dial_time,
-            dial_succeeded,
-        })
-    }
-
-    pub fn send_new_peer_request(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
+    pub fn send_exchange_request(&self, peer_id: PeerId, peer_type: PeerType) -> Result<(), anyhow::Error> {
         self.broadcast(DiagnosticData::PeerRequest {
             peer_id,
-            timestamp: EpochTime::now(),
+            peer_type,
+            timestamp: SystemTime::now(),
         })
     }
 
-    pub fn send_peer_response(&self, peer_id: PeerId, number_of_peers: usize) -> Result<(), anyhow::Error> {
+    pub fn send_peer_response(
+        &self,
+        peer_id: PeerId,
+        number_of_peers: usize,
+        peer_type: PeerType,
+    ) -> Result<(), anyhow::Error> {
         self.broadcast(DiagnosticData::PeerResponse {
             peer_id,
+            peer_type,
             number_of_peers,
-            timestamp: EpochTime::now(),
+            timestamp: SystemTime::now(),
         })
     }
 
-    pub fn send_peer_connected(&self, peer_id: PeerId) -> Result<(), anyhow::Error> {
+    pub fn send_peer_connected(&self, peer_id: PeerId, peer_type: PeerType) -> Result<(), anyhow::Error> {
         self.broadcast(DiagnosticData::PeerConnected {
             peer_id,
-            timestamp: EpochTime::now(),
+            peer_type,
+            timestamp: SystemTime::now(),
         })
     }
 }

--- a/p2pool/src/server/mod.rs
+++ b/p2pool/src/server/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 mod config;
+use std::{fmt, fmt::Display};
+
 pub use config::*;
 
 #[allow(clippy::module_inception)]
@@ -14,3 +16,24 @@ pub mod http;
 pub mod p2p;
 
 pub const PROTOCOL_VERSION: u64 = 33;
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub(crate) enum PeerType {
+    SeedPeer,
+    RelayPeer,
+    PrivatePeer,
+    NonSquadPeer,
+    Unknown,
+}
+
+impl Display for PeerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PeerType::SeedPeer => write!(f, "SeedPeer"),
+            PeerType::RelayPeer => write!(f, "RelayPeer"),
+            PeerType::PrivatePeer => write!(f, "PrivatePeer"),
+            PeerType::NonSquadPeer => write!(f, "NonSquadPeer"),
+            PeerType::Unknown => write!(f, "UnknownPeerType"),
+        }
+    }
+}

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -80,6 +80,7 @@ use crate::{
             peer_store::{AddPeerStatus, PeerStore, PeerStoreRecord},
             relay_store::RelayStore,
         },
+        PeerType,
         PROTOCOL_VERSION,
     },
     sharechain::{
@@ -796,6 +797,9 @@ where S: ShareChain
                 .behaviour_mut()
                 .direct_peer_exchange
                 .send_request(peer, request);
+            if let Some(client) = &self.diagnostics_broadcast_client {
+                let _unused = client.send_exchange_request(*peer, self.peer_type(peer).await);
+            }
         } else {
             error!(target: LOG_TARGET, "Failed to create peer info");
         }
@@ -1110,7 +1114,8 @@ where S: ShareChain
 
                 // Update peer diagnostics
                 if let Some(client) = &self.diagnostics_broadcast_client {
-                    let _unused = client.send_peer_response(peer_id, num_peers_received);
+                    let _unused =
+                        client.send_peer_response(peer_id, num_peers_received, self.peer_type(&peer_id).await);
                 }
 
                 // if we are a seed peer, end here
@@ -1387,6 +1392,24 @@ where S: ShareChain
         }
     }
 
+    async fn peer_type(&self, peer_id: &PeerId) -> PeerType {
+        let network_peer_store = self.network_peer_store.read().await;
+        if network_peer_store.is_seed_peer(peer_id) {
+            return PeerType::SeedPeer;
+        }
+        if network_peer_store.get(peer_id).is_some() {
+            if self.relay_store.read().await.is_relay(peer_id) {
+                PeerType::RelayPeer
+            } else {
+                PeerType::PrivatePeer
+            }
+        } else if network_peer_store.non_squad_peers().get(&peer_id.to_base58()).is_some() {
+            PeerType::NonSquadPeer
+        } else {
+            PeerType::Unknown
+        }
+    }
+
     /// Main method to handle libp2p events.
     #[allow(clippy::too_many_lines)]
     async fn handle_event(&mut self, event: SwarmEvent<ServerNetworkBehaviourEvent>) {
@@ -1416,18 +1439,22 @@ where S: ShareChain
                     "Connection established: {peer_id:?} -> {endpoint:?} ({num_established:?}/{concurrent_dial_errors:?}/{established_in:?})"
                 );
                 if let Some(client) = &self.diagnostics_broadcast_client {
-                    let _unused = client.send_peer_connected(peer_id);
+                    let _unused = client.send_peer_connected(peer_id, self.peer_type(&peer_id).await);
                 }
                 // if num_established == NonZeroU32::new(1).expect("Can't fail") {
                 self.initiate_direct_peer_exchange(&peer_id).await;
-                if let Some(client) = &self.diagnostics_broadcast_client {
-                    let _unused = client.send_new_peer_request(peer_id);
-                }
                 // self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
                 // }
             },
             SwarmEvent::Dialing { peer_id, .. } => {
                 info!(target: LOG_TARGET, "Dialing: {peer_id:?}");
+                if let Some(diagnostics_broadcast_client) = &self.diagnostics_broadcast_client {
+                    if let Some(peer_id) = peer_id {
+                        let _unused =
+                            diagnostics_broadcast_client.send_new_peer(peer_id, self.peer_type(&peer_id).await);
+                        debug!(target: LOG_TARGET, "[Diagnostics] Attemptig to dial peer '{:?}'", peer_id);
+                    }
+                }
             },
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(target: LOG_TARGET, "Listening on {address:?}");
@@ -2701,47 +2728,81 @@ where S: ShareChain
         }
     }
 
-    async fn get_connected_peer_records(
-        &self,
-        connected_peers: &[PeerId],
-    ) -> (Vec<PeerStoreRecord>, Vec<PeerStoreRecord>, Vec<PeerStoreRecord>) {
+    async fn sort_and_verify_peers(&self, peer_list: &[PeerId]) -> (Vec<PeerId>, Vec<PeerId>, Vec<PeerId>) {
         let network_peer_store = self.network_peer_store.read().await;
-        // All connected peers
-        let connected_peer_records: Vec<_> = connected_peers
+
+        // Existing peer records
+        let existing_peer_records = peer_list
+            .iter()
+            .filter_map(|peer| network_peer_store.get(peer).cloned())
+            .collect::<Vec<_>>();
+
+        // Verified peer list (peers that we have records for)
+        let verified_peer_list = existing_peer_records.iter().map(|p| p.peer_id).collect::<Vec<_>>();
+
+        // Seeds
+        let known_seeds = network_peer_store.all_seed_peers();
+        let seeds = known_seeds
+            .into_iter()
+            .filter(|p| verified_peer_list.contains(p))
+            .collect::<Vec<_>>();
+
+        // Same squad only
+        let same_squad_peers = existing_peer_records
+            .iter()
+            .filter(|p| p.peer_info.squad == self.squad)
+            .map(|p| p.peer_id)
+            .collect::<Vec<_>>();
+
+        // Non-seed peers
+        let non_seed_peers = same_squad_peers
+            .iter()
+            .filter(|p| !seeds.contains(p))
+            .copied()
+            .collect::<Vec<_>>();
+
+        // Relay peers
+        let known_relays = self.relay_store.read().await.get_relay_peer_ids();
+        let relays = known_relays
+            .into_iter()
+            .filter(|p| non_seed_peers.contains(p))
+            .collect::<Vec<_>>();
+
+        // Private peers
+        let private_peers = non_seed_peers
+            .into_iter()
+            .filter(|p| !relays.contains(p))
+            .collect::<Vec<_>>();
+
+        (seeds, private_peers, relays)
+    }
+
+    async fn get_same_squad_peer_records(&self, filter_peers: &[PeerId], is_relay: bool) -> Vec<PeerStoreRecord> {
+        let network_peer_store = self.network_peer_store.read().await;
+        let same_squad_peers = network_peer_store.get_known_same_squad_peers();
+        // Not out own peer id
+        let own_peer_id = self.swarm.local_peer_id();
+        let mut same_squad_peers = same_squad_peers
+            .iter()
+            .filter(|p| p != &own_peer_id)
+            .collect::<Vec<_>>();
+        // Apply peer filter
+        same_squad_peers.retain(|p| !filter_peers.contains(p));
+        // Apply relay filter
+        let known_relays = self.relay_store.read().await.get_relay_peer_ids();
+        same_squad_peers.retain(|p| {
+            if is_relay {
+                known_relays.contains(p)
+            } else {
+                !known_relays.contains(p)
+            }
+        });
+        // Get peer records
+        let peer_records: Vec<_> = same_squad_peers
             .iter()
             .filter_map(|peer| network_peer_store.get(peer).cloned())
             .collect();
-        // Seeds
-        let seeds = connected_peer_records
-            .iter()
-            .filter(|p| network_peer_store.is_seed_peer(&p.peer_id))
-            .cloned()
-            .collect::<Vec<_>>();
-        // Same squad only
-        let same_squad_connected_peer_records = connected_peer_records
-            .iter()
-            .filter(|p| p.peer_info.squad == self.squad)
-            .cloned()
-            .collect::<Vec<_>>();
-        // All other peers
-        let other_peers = same_squad_connected_peer_records
-            .iter()
-            .filter(|p| !network_peer_store.is_seed_peer(&p.peer_id))
-            .cloned()
-            .collect::<Vec<_>>();
-        // Peers without public addresses
-        let peers = other_peers
-            .iter()
-            .filter(|p| p.peer_info.public_addresses().is_empty())
-            .cloned()
-            .collect::<Vec<_>>();
-        // Relay peers
-        let relays = other_peers
-            .iter()
-            .filter(|p| !p.peer_info.public_addresses().is_empty())
-            .cloned()
-            .collect::<Vec<_>>();
-        (seeds, peers, relays)
+        peer_records
     }
 
     /// Main loop of the diagnostic service that drives the events and libp2p swarm forward.
@@ -2785,8 +2846,10 @@ where S: ShareChain
             .ok_or_else(|| anyhow_error("Diagnostics receiver client not available in diagnostic mode"))?;
         let mut diagnostic_state = DiagnosticState::ConnectToSeedPeers;
         let mut start = Instant::now();
-        let uptime = Instant::now();
-        let mut processed_peers = Vec::new();
+        let uptime: Instant = Instant::now();
+        let mut dialed_seed_peers = Vec::new();
+        let mut dialed_private_peers = Vec::new();
+        let mut dialed_relay_peers = Vec::new();
         loop {
             select! {
                 // biased;
@@ -2798,99 +2861,68 @@ where S: ShareChain
                     match diagnostic_state {
                         DiagnosticState::ConnectToSeedPeers => {
                             info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
-                            let seed_peers = self.parse_seed_peers().await?;
-                            let mut number_dialed = 0;
-                            for (peer, addr) in &seed_peers {
-                                info!(target: LOG_TARGET, "[Diagnostics] Adding seed peer: {:?} -> {:?}", peer, addr);
-                                let timer = Instant::now();
-                                self.swarm.add_peer_address(*peer, addr.clone());
-                                match self.swarm.dial(DialOpts::peer_id(*peer).build()) {
-                                    Ok(_) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_seed_peer(
-                                            *peer,
-                                            timer.elapsed(),
-                                            true,
-                                        );
-                                        self.network_peer_store.write().await.add_seed_peers(vec![*peer]);
+                            if !dialed_seed_peers.is_empty() {
+                                let seed_peers = self.parse_seed_peers().await?;
+                                self.network_peer_store.write().await.add_seed_peers(seed_peers.keys().copied().collect());
+                                for (peer, addr) in &seed_peers {
+                                    info!(target: LOG_TARGET, "[Diagnostics] Adding seed peer: {:?} -> {:?}", peer, addr);
+                                    self.swarm.add_peer_address(*peer, addr.clone());
+                                    if self.swarm.dial(DialOpts::peer_id(*peer).build()).is_ok() {
+                                        let _unused = diagnostics_broadcast_client.send_new_peer(*peer, PeerType::SeedPeer);
                                         debug!(
                                             target: LOG_TARGET,
                                             "[Diagnostics] Successfully dialed seed peer '{peer}' at '{addr}'"
                                         );
-                                        number_dialed += 1;
-                                    },
-                                    Err(e) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_seed_peer(
-                                            *peer,
-                                            timer.elapsed(),
-                                            false,
-                                        );
-                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial seed peer: {e:?}");
-                                    },
+                                    }
+                                    dialed_seed_peers.push(*peer);
                                 }
-                                processed_peers.push(*peer);
                             }
-
-                            if number_dialed > 0 {
-                                diagnostic_state = DiagnosticState::WaitForSeedPeersDownload;
-                                start = Instant::now();
-                            } else if start.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no seed peers could be dialed, exiting.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::Done;
-                            } else {
-                                // Nothing here
+                            // Verify that we have at least some seed peers connected
+                            if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
+                                let (seeds, _privates, _relays) = self.sort_and_verify_peers(&connected_peers).await;
+                                if !seeds.is_empty() {
+                                    diagnostic_state = DiagnosticState::WaitForSeedPeersDownload;
+                                    start = Instant::now();
+                                } else if start.elapsed() > Duration::from_secs(60) {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] {:?} failed, no seed peers connected",
+                                        diagnostic_state
+                                    );
+                                    diagnostic_state = DiagnosticState::Done;
+                                } else {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] {:?} waiting for seed peers to connect...",
+                                        diagnostic_state
+                                    );
+                                    continue;
+                                }
                             }
                         },
                         DiagnosticState::WaitForSeedPeersDownload => {
                             info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
-                            if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
-                                let (seeds, _privates, _relays) = self.get_connected_peer_records(&connected_peers).await;
-                                if seeds.is_empty() {
-                                    if start.elapsed() > Duration::from_secs(30) {
-                                        warn!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] {:?} failed, no seed peers connected",
-                                            diagnostic_state
-                                        );
-                                        diagnostic_state = DiagnosticState::Done;
-                                    } else {
-                                        debug!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] {:?} waiting for seed peers to connect...",
-                                            diagnostic_state
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-
-                            let (mut seen_all, mut seen_some) = (true, false);
+                            let (mut seen_all, mut seen_count) = (true, 0);
                             if let Ok(seeds_data) = diagnostics_receiver_client.get_seed_peer_diagnostic_info().await {
                                 seeds_data.iter().for_each(|(_peer, data)| {
                                     if data.response_time.is_none() {
                                         seen_all = false;
-                                    }
-                                });
-                                seeds_data.iter().for_each(|(_peer, data)| {
-                                    if data.response_time.is_some() {
-                                        seen_some = true;
+                                    } else {
+                                        seen_count += 1;
                                     }
                                 });
                             }
 
                             if seen_all {
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
                                 start = Instant::now();
-                            } else if start.elapsed() > Duration::from_secs(60) && seen_some {
+                            } else if start.elapsed() > Duration::from_secs(60) && seen_count > 0 && seen_count < 5 {
                                 warn!(
                                     target: LOG_TARGET,
-                                    "[Diagnostics] {:?} sporadic, not all seed peers responded.",
-                                    diagnostic_state
+                                    "[Diagnostics] {:?} non-definitive, only {} peers responded.",
+                                    diagnostic_state, seen_count
                                 );
-                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
                             } else if start.elapsed() > Duration::from_secs(60) {
                                 warn!(
                                     target: LOG_TARGET,
@@ -2902,241 +2934,162 @@ where S: ShareChain
                                 // Nothing here
                             }
                         }
-                        DiagnosticState::ConnectToRelayPeers => {
+                        DiagnosticState::ConnectToPrivatePeers => {
                             info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
-                            let network_peer_store = self.network_peer_store.read().await;
-                            let other_peers = network_peer_store.get_known_peers();
-                            let mut other_peers = other_peers.iter().collect_vec();
-                            // Retain only peers that have not been processed
-                            other_peers.retain(|p| !processed_peers.contains(p));
-                            let other_peer_records: Vec<_> = other_peers
-                                .iter()
-                                .filter_map(|peer| network_peer_store.get(peer).cloned())
-                                .collect();
-                            // Retain only peers that have public addresses
-                            let peer_records = other_peer_records
-                                .iter()
-                                .filter(|p| !p.peer_info.public_addresses().is_empty())
-                                .cloned()
-                                .collect::<Vec<_>>();
-                            // Select 5 random peers
-                            let peer_records = peer_records.choose_multiple(&mut thread_rng(), 5).collect_vec();
-
-                            let mut number_dialed = 0;
+                            let peer_records = self.get_same_squad_peer_records(&dialed_seed_peers, false).await;
+                            debug!(
+                                target: LOG_TARGET,
+                                "[Diagnostics] {:?} Found {} private peers to connect to",
+                                diagnostic_state,
+                                peer_records.len()
+                            );
+                            // Select some random peers
+                            let mut peer_records = peer_records.choose_multiple(&mut thread_rng(), 10).collect_vec();
+                            peer_records.retain(|&x| !dialed_private_peers.contains(&x.peer_id));
+                            // Dial selected peers
                             for record in &peer_records {
                                 let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
                                     record.peer_info.public_addresses().clone()
                                 ).extend_addresses_through_behaviour().build();
-                                let timer = Instant::now();
-                                match self.swarm.dial(dial_opts) {
-                                    Ok(_) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_relay_peer(
-                                            record.peer_id,
-                                            timer.elapsed(),
-                                            true,
-                                        );
-                                        debug!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] Successfully dialed peer '{:?}'",
-                                            record.peer_id
-                                        );
-                                        number_dialed += 1;
-                                    },
-                                    Err(e) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_relay_peer(
-                                            record.peer_id,
-                                            timer.elapsed(),
-                                            false,
-                                        );
-                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial peer: {e:?}");
-                                    },
+                                if  self.swarm.dial(dial_opts).is_ok() {
+                                    let _unused = diagnostics_broadcast_client.send_new_peer(
+                                        record.peer_id,
+                                        PeerType::PrivatePeer
+                                    );
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] Successfully dialed peer '{:?}'",
+                                        record.peer_id
+                                    );
+                                    dialed_private_peers.push(record.peer_id);
                                 };
-                                processed_peers.push(record.peer_id);
                             }
-
-                            if number_dialed > 0 {
-                                diagnostic_state = DiagnosticState::WaitForRelayPeersDownload;
-                                start = Instant::now();
-                            } else if start.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no public peers could be dialed. Exiting.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
-                            } else {
-                                // Nothing here
-                            }
-                        },
-                        DiagnosticState::WaitForRelayPeersDownload => {
-                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            // Verify that we have enough private peers connected
                             if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
-                                let (_seeds, _privates, relays) = self.get_connected_peer_records(&connected_peers).await;
-                                if relays.is_empty() {
-                                    if start.elapsed() > Duration::from_secs(30) {
-                                        warn!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] {:?} failed, no relay peers connected",
-                                            diagnostic_state
-                                        );
-                                        diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
-                                    } else {
-                                        debug!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] {:?} waiting for relay peers to connect...",
-                                            diagnostic_state
-                                        );
-                                        continue;
-                                    }
+                                let (_seeds, privates, _relays) = self.sort_and_verify_peers(&connected_peers).await;
+                                if privates.len() >= 10 {
+                                    diagnostic_state = DiagnosticState::WaitForPrivatePeersDownload;
+                                    start = Instant::now();
+                                } else if start.elapsed() > Duration::from_secs(60) && privates.is_empty() {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] {:?} failed, no private peers connected",
+                                        diagnostic_state
+                                    );
+                                    diagnostic_state = DiagnosticState::ConnectToRelayPeers;
+                                } else {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] {:?} waiting for private peers to connect...",
+                                        diagnostic_state
+                                    );
+                                    continue;
                                 }
                             }
-
-                            let (mut seen_all, mut seen_some) = (true, false);
-                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
-                                relays_data.iter().for_each(|(_peer, data)| {
-                                    if data.response_time.is_none() {
-                                        seen_all = false;
-                                    }
-                                });
-                                relays_data.iter().for_each(|(_peer, data)| {
+                        },
+                        DiagnosticState::WaitForPrivatePeersDownload => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            let mut seen_count = 0;
+                            if let Ok(peers_data) = diagnostics_receiver_client.get_private_peer_diagnostic_info().await {
+                                peers_data.iter().for_each(|(_peer, data)| {
                                     if data.response_time.is_some() {
-                                        seen_some = true;
+                                        seen_count += 1;
                                     }
                                 });
                             }
 
-                            if seen_all {
-                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                            if seen_count >= 5 {
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
                                 start = Instant::now();
-                            } else if start.elapsed() > Duration::from_secs(60) && seen_some {
+                            } else if start.elapsed() > Duration::from_secs(60) && seen_count > 0 {
                                 warn!(
                                     target: LOG_TARGET,
-                                    "[Diagnostics] {:?} sporadic, not all peers responded.",
-                                    diagnostic_state
+                                    "[Diagnostics] {:?} non-definitive, only {} peers responded.",
+                                    diagnostic_state, seen_count
                                 );
-                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
                             } else if start.elapsed() > Duration::from_secs(60) {
                                 warn!(
                                     target: LOG_TARGET,
                                     "[Diagnostics] {:?} failed, no peers responded.",
                                     diagnostic_state
                                 );
-                                diagnostic_state = DiagnosticState::ConnectToPrivatePeers;
+                                diagnostic_state = DiagnosticState::ConnectToRelayPeers;
                             } else {
                                 // Nothing here
                             }
                         }
-                        DiagnosticState::ConnectToPrivatePeers => {
+                        DiagnosticState::ConnectToRelayPeers => {
                             info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
-                            let network_peer_store = self.network_peer_store.read().await;
-                            let other_peers = network_peer_store.get_known_peers();
-                            let mut other_peers = other_peers.iter().collect_vec();
-                            // Retain only peers that have not been processed
-                            other_peers.retain(|p| !processed_peers.contains(p));
-                            let other_peer_records: Vec<_> = other_peers
-                                .iter()
-                                .filter_map(|peer| network_peer_store.get(peer).cloned())
-                                .collect();
-                            // Retain only peers that have no public addresses
-                            let peer_records = other_peer_records
-                                .iter()
-                                .filter(|p| p.peer_info.public_addresses().is_empty())
-                                .cloned()
-                                .collect::<Vec<_>>();
-                            // Select 5 random peers
-                            let peer_records = peer_records.choose_multiple(&mut thread_rng(), 5).collect_vec();
-
-                            let mut number_dialed = 0;
+                            let peer_records = self.get_same_squad_peer_records(&dialed_seed_peers, true).await;
+                            debug!(
+                                target: LOG_TARGET,
+                                "[Diagnostics] {:?} Found {} relay peers to connect to",
+                                diagnostic_state,
+                                peer_records.len()
+                            );
+                            // Select some random peers
+                            let mut peer_records = peer_records.choose_multiple(&mut thread_rng(), 10).collect_vec();
+                            peer_records.retain(|&x| !dialed_relay_peers.contains(&x.peer_id));
+                            // Dial selected peers
                             for record in &peer_records {
                                 let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
                                     record.peer_info.public_addresses().clone()
                                 ).extend_addresses_through_behaviour().build();
-                                let timer = Instant::now();
-                                match self.swarm.dial(dial_opts) {
-                                    Ok(_) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_private_peer(
-                                            record.peer_id,
-                                            timer.elapsed(),
-                                            true,
-                                        );
-                                        debug!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] Successfully dialed peer '{:?}'",
-                                            record.peer_id
-                                        );
-                                        number_dialed += 1;
-                                    },
-                                    Err(e) => {
-                                        let _unused = diagnostics_broadcast_client.send_new_private_peer(
-                                            record.peer_id,
-                                            timer.elapsed(),
-                                            false,
-                                        );
-                                        warn!(target: LOG_TARGET, "[Diagnostics] Failed to dial peer: {e:?}");
-                                    },
+                                if self.swarm.dial(dial_opts).is_ok() {
+                                    let _unused = diagnostics_broadcast_client.send_new_peer(
+                                        record.peer_id,
+                                        PeerType::RelayPeer
+                                    );
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] Successfully dialed peer '{:?}'",
+                                        record.peer_id
+                                    );
                                 };
-                                processed_peers.push(record.peer_id);
+                                dialed_relay_peers.push(record.peer_id);
                             }
-
-                            if number_dialed > 0 {
-                                diagnostic_state = DiagnosticState::WaitForPrivatePeersDownload;
-                                start = Instant::now();
-                            } else if start.elapsed() > Duration::from_secs(60) {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "[Diagnostics] {:?} failed, no non-public peers could be dialed.",
-                                    diagnostic_state
-                                );
-                                diagnostic_state = DiagnosticState::Done;
-                            } else {
-                                // Nothing here
-                            }
-                        },
-                        DiagnosticState::WaitForPrivatePeersDownload => {
-                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            // Verify that we have enough relay peers connected
                             if let Ok(connected_peers) = diagnostics_receiver_client.get_connected_peers().await {
-                                let (_seeds, privates, _relays) = self.get_connected_peer_records(&connected_peers).await;
-                                if privates.is_empty() {
-                                    if start.elapsed() > Duration::from_secs(30) {
-                                        warn!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] {:?} failed, no private peers connected",
-                                            diagnostic_state
-                                        );
-                                        diagnostic_state = DiagnosticState::Done;
-                                    } else {
-                                        debug!(
-                                            target: LOG_TARGET,
-                                            "[Diagnostics] {:?} waiting for private peers to connect...",
-                                            diagnostic_state
-                                        );
-                                        continue;
-                                    }
+                                let (_seeds, _privates, relays) = self.sort_and_verify_peers(&connected_peers).await;
+                                if relays.len() >= 10 {
+                                    diagnostic_state = DiagnosticState::WaitForRelayPeersDownload;
+                                    start = Instant::now();
+                                } else if start.elapsed() > Duration::from_secs(60) && relays.is_empty() {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] {:?} failed, no relay peers connected",
+                                        diagnostic_state
+                                    );
+                                    diagnostic_state = DiagnosticState::Done;
+                                } else {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "[Diagnostics] {:?} waiting for relay peers to connect...",
+                                        diagnostic_state
+                                    );
+                                    continue;
                                 }
                             }
-
-                            let (mut seen_all, mut seen_some) = (true, false);
-                            if let Ok(peers_data) = diagnostics_receiver_client.get_private_peer_diagnostic_info().await {
-                                peers_data.iter().for_each(|(_peer, data)| {
-                                    if data.response_time.is_none() {
-                                        seen_all = false;
-                                    }
-                                });
-                                peers_data.iter().for_each(|(_peer, data)| {
+                        },
+                        DiagnosticState::WaitForRelayPeersDownload => {
+                            info!(target: LOG_TARGET, "[Diagnostics] {:?}... ({:.2?})", diagnostic_state, uptime.elapsed());
+                            let mut seen_count  = 0;
+                            if let Ok(relays_data) = diagnostics_receiver_client.get_relay_peer_diagnostic_info().await {
+                                relays_data.iter().for_each(|(_peer, data)| {
                                     if data.response_time.is_some() {
-                                        seen_some = true;
+                                        seen_count += 1;
                                     }
                                 });
                             }
 
-                            if seen_all {
+                            if seen_count > 5 {
                                 diagnostic_state = DiagnosticState::Done;
-                                start = Instant::now();
-                            } else if start.elapsed() > Duration::from_secs(60) && seen_some {
+                            } else if start.elapsed() > Duration::from_secs(60) && seen_count > 0 {
                                 warn!(
                                     target: LOG_TARGET,
-                                    "[Diagnostics] {:?} sporadic, not all peers responded.",
-                                    diagnostic_state
+                                    "[Diagnostics] {:?} non-definitive, only {} peers responded.",
+                                    diagnostic_state, seen_count
                                 );
                                 diagnostic_state = DiagnosticState::Done;
                             } else if start.elapsed() > Duration::from_secs(60) {
@@ -3200,19 +3153,19 @@ where S: ShareChain
                                 {
                                     "summary": {
                                         "1. Connect to DNS seeds             _":
-                                            seeds_data.iter().any(|peer| peer.dial_succeeded),
+                                            seeds_data.iter().any(|peer| peer.connected_at.is_some()),
                                         "2. Download peers from DNS seeds    _":
                                             seeds_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
                                         "3. Number of DNS seeds responded    _":
                                             seeds_data.iter().filter(|peer| peer.response_time.is_some()).count(),
                                         "4. Connect to relay peers           _":
-                                            relays_data.iter().any(|peer| peer.dial_succeeded),
+                                            relays_data.iter().any(|peer| peer.connected_at.is_some()),
                                         "5. Download peers from relay peers  _":
                                             relays_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
                                         "6. Number of relay peers responded  _":
                                             relays_data.iter().filter(|peer| peer.response_time.is_some()).count(),
                                         "7. Connect to private peers         _":
-                                            private_peers_data.iter().any(|peer| peer.dial_succeeded),
+                                            private_peers_data.iter().any(|peer| peer.connected_at.is_some()),
                                         "8. Download peers from private peers_":
                                             private_peers_data.iter().any(|peer| peer.number_of_peers.unwrap_or(0) > 0),
                                         "9. Number of private peers responded_":

--- a/p2pool/src/server/p2p/peer_store.rs
+++ b/p2pool/src/server/p2p/peer_store.rs
@@ -167,6 +167,10 @@ impl PeerStore {
         self.seed_peers.contains(peer_id)
     }
 
+    pub fn all_seed_peers(&self) -> Vec<PeerId> {
+        self.seed_peers.clone()
+    }
+
     pub fn num_catch_ups(&self, peer: &PeerId) -> Option<u64> {
         self.whitelist_peers
             .get(&peer.to_base58())
@@ -197,12 +201,25 @@ impl PeerStore {
         &self.greylist_peers
     }
 
+    pub fn non_squad_peers(&self) -> &HashMap<String, PeerStoreRecord> {
+        &self.non_squad_peers
+    }
+
     pub fn get_known_peers(&self) -> HashSet<PeerId> {
         self.whitelist_peers
             .keys()
             .chain(self.greylist_peers.keys())
             .chain(self.blacklist_peers.keys())
             .chain(self.non_squad_peers.keys())
+            .filter_map(|peer_id| PeerId::from_str(peer_id).ok())
+            .collect()
+    }
+
+    pub fn get_known_same_squad_peers(&self) -> HashSet<PeerId> {
+        self.whitelist_peers
+            .keys()
+            .chain(self.greylist_peers.keys())
+            .chain(self.blacklist_peers.keys())
             .filter_map(|peer_id| PeerId::from_str(peer_id).ok())
             .collect()
     }

--- a/p2pool/src/server/p2p/relay_store.rs
+++ b/p2pool/src/server/p2p/relay_store.rs
@@ -31,6 +31,14 @@ impl RelayStore {
             is_circuit_established: false,
         });
     }
+
+    pub fn get_relay_peer_ids(&self) -> Vec<PeerId> {
+        self.possible_relays.keys().copied().collect()
+    }
+
+    pub fn is_relay(&self, peer_id: &PeerId) -> bool {
+        self.possible_relays.contains_key(peer_id)
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Description
---
Improved diagnostic mode using nextnet system-level tests.

Motivation and Context
---
The diagnostics did not perform well in a system-level environment.

How Has This Been Tested?
---
Nextnet system-level tests. Summary file below:
```json
{
  "local_node": {
    "1. squad": "default_1",
    "2. peer_id": "12D3KooWLUn3zn9unTifPX44UwaPdkdtvSRKyoj8RazrcQ56eGaX",
    "3. public_addresses": [
      "/ip4/183.80.34.230/udp/63989/quic-v1/p2p/12D3KooWDcUSp3ZTnPFvWbCB64VZeedVAYSqRXugTPrtnKm5zqDC/p2p-circuit/p2p/12D3KooWLUn3zn9unTifPX44UwaPdkdtvSRKyoj8RazrcQ56eGaX",
      "/ip4/113.167.210.5/udp/23986/quic-v1/p2p/12D3KooWH3NHtBTYVDWVf4aGhSd6SHjWVrZffkUwof4ok75tzky2/p2p-circuit/p2p/12D3KooWLUn3zn9unTifPX44UwaPdkdtvSRKyoj8RazrcQ56eGaX"
    ]
  }
}
{
  "summary": {
    " 1. Connect to DNS seeds             ": true,
    " 2. Download peers from DNS seeds    ": true,
    " 3. Number of DNS seeds connected    ": 5,
    " 4. Number of DNS seeds responded    ": 5,
    " 5. Connect to relay peers           ": true,
    " 6. Download peers from relay peers  ": true,
    " 7. Number of relay peers connected  ": 12,
    " 8. Number of relay peers responded  ": 12,
    " 9. Connect to private peers         ": true,
    "10. Download peers from private peers": true,
    "11. Number of private peers connected": 70,
    "12. Number of private peers responded": 2
  }
}
{
  "seeds (1st 10)": [
    {
      "connected_at": "2025-03-21 17:29:21.991",
      "number_of_peers": 400,
      "peer_id": "12D3KooWSbJLEQwkfYnohxahhQC4N69yvH7k5jyiijtny4htMZKF",
      "requested_peers_at": "2025-03-21 17:29:21.991",
      "response_time (s)": "1.191"
    },
    {
      "connected_at": "2025-03-21 17:29:21.943",
      "number_of_peers": 300,
      "peer_id": "12D3KooWD6GY3c8cz6AwKaDaqmqGCbmewhjKT5ULN9JUB5oUgWjS",
      "requested_peers_at": "2025-03-21 17:29:21.943",
      "response_time (s)": "1.038"
    },
    {
      "connected_at": "2025-03-21 17:29:21.947",
      "number_of_peers": 100,
      "peer_id": "12D3KooWQkhWPSKfSAHq25MPy4RWuKoY7fvJn8J5rAV7bo5q59DX",
      "requested_peers_at": "2025-03-21 17:29:21.947",
      "response_time (s)": "0.891"
    },
    {
      "connected_at": "2025-03-21 17:29:21.962",
      "number_of_peers": 100,
      "peer_id": "12D3KooWKSo7o3WfVuUg869qCYgwsumaiZYiAHx9dnPPF2WRuNfp",
      "requested_peers_at": "2025-03-21 17:29:21.962",
      "response_time (s)": "0.928"
    },
    {
      "connected_at": "2025-03-21 17:29:22.093",
      "number_of_peers": 100,
      "peer_id": "12D3KooWCyVRELcqHNrsokdygFsBmHDp3sBFy18KgrVzz8Cj4BQ6",
      "requested_peers_at": "2025-03-21 17:29:22.093",
      "response_time (s)": "1.507"
    }
  ]
}
{
  "relays (1st 10)": [
    {
      "connected_at": "2025-03-21 17:29:25.911",
      "number_of_peers": 734,
      "peer_id": "12D3KooWMLB79n4wBJMk8Mmsuu3S2vPZRRbZ5KYR6Giw1jexghv1",
      "requested_peers_at": "2025-03-21 17:29:25.912",
      "response_time (s)": "1.297"
    },
    {
      "connected_at": "2025-03-21 17:29:25.750",
      "number_of_peers": 475,
      "peer_id": "12D3KooWMVLvmmdtihMWVK2y67kgy3t5LEGq2kriBZxHuohMbzxk",
      "requested_peers_at": "2025-03-21 17:29:25.753",
      "response_time (s)": "1.328"
    },
    {
      "connected_at": "2025-03-21 17:29:25.885",
      "number_of_peers": 321,
      "peer_id": "12D3KooWGSxxgYN189hwBKv4AuWLaQ17HfKn2awYw2MChTyjAFGg",
      "requested_peers_at": "2025-03-21 17:29:25.888",
      "response_time (s)": "1.183"
    },
    {
      "connected_at": "2025-03-21 17:29:25.793",
      "number_of_peers": 201,
      "peer_id": "12D3KooWJ1tcU92V176JYnxn4B1tHb4CBiGrfwjKAqGbWkR7mgT5",
      "requested_peers_at": "2025-03-21 17:29:25.795",
      "response_time (s)": "1.614"
    },
    {
      "connected_at": "2025-03-21 17:29:25.795",
      "number_of_peers": 201,
      "peer_id": "12D3KooWJ3VMidyzqa3cv5FCYQrEE5PemGnqRMsYtYtH9rzmceaL",
      "requested_peers_at": "2025-03-21 17:29:25.797",
      "response_time (s)": "1.619"
    },
    {
      "connected_at": "2025-03-21 17:29:26.158",
      "number_of_peers": 107,
      "peer_id": "12D3KooWQLQJMqUAVeDNyJqG3HTcqG6Ju5VRWSxqG1U2SoiU9frZ",
      "requested_peers_at": "2025-03-21 17:29:26.160",
      "response_time (s)": "1.961"
    },
    {
      "connected_at": "2025-03-21 17:29:25.938",
      "number_of_peers": 106,
      "peer_id": "12D3KooWRZ9YFFfFSfCwyeDhwwKKrxwkBzcq2sWA7anDmgcv6cRf",
      "requested_peers_at": "2025-03-21 17:29:25.941",
      "response_time (s)": "2.525"
    },
    {
      "connected_at": "2025-03-21 17:29:27.052",
      "number_of_peers": 101,
      "peer_id": "12D3KooWDcUSp3ZTnPFvWbCB64VZeedVAYSqRXugTPrtnKm5zqDC",
      "requested_peers_at": "2025-03-21 17:29:27.054",
      "response_time (s)": "3.324"
    },
    {
      "connected_at": "2025-03-21 17:29:27.343",
      "number_of_peers": 77,
      "peer_id": "12D3KooWH3NHtBTYVDWVf4aGhSd6SHjWVrZffkUwof4ok75tzky2",
      "requested_peers_at": "2025-03-21 17:29:27.346",
      "response_time (s)": "5.008"
    },
    {
      "connected_at": "2025-03-21 17:29:26.092",
      "number_of_peers": 38,
      "peer_id": "12D3KooWLUTbRfafkTM4KPU7GP4sBHBYkatGVeR6VtCrx4dnx1SE",
      "requested_peers_at": "2025-03-21 17:29:26.094",
      "response_time (s)": "8.736"
    }
  ]
}
{
  "private peers (1st 10)": [
    {
      "connected_at": "2025-03-21 17:29:29.224",
      "number_of_peers": 17,
      "peer_id": "12D3KooWCezoJ81VneGngCTVAEDTtEjARQBu4d5fq79YUztKbfHi",
      "requested_peers_at": "2025-03-21 17:29:29.227",
      "response_time (s)": "31.511"
    },
    {
      "connected_at": "2025-03-21 17:29:32.343",
      "number_of_peers": 6,
      "peer_id": "12D3KooWPy8CLnTA6RnX8ugCYWdERdxYp6i4tcyrW8xUNs4nvdKN",
      "requested_peers_at": "2025-03-21 17:29:32.348",
      "response_time (s)": "31.733"
    },
    {
      "connected_at": "2025-03-21 17:29:26.748",
      "number_of_peers": null,
      "peer_id": "12D3KooWL2WX9Wu6kFCfvhDt9pbaiUT9GD3HUwDf5cQVKSwUp1N4",
      "requested_peers_at": "2025-03-21 17:29:26.749",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.460",
      "number_of_peers": null,
      "peer_id": "12D3KooWJkaYaEsZv5SpnRuSLSnu8KQMA3U7CMygNDxKerA6VvDr",
      "requested_peers_at": "2025-03-21 17:29:27.464",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.494",
      "number_of_peers": null,
      "peer_id": "12D3KooWP8zWBTThMoiuxWUJeSHGk2tm2GaGN3RJ2vthURYH6JYP",
      "requested_peers_at": "2025-03-21 17:29:27.499",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.523",
      "number_of_peers": null,
      "peer_id": "12D3KooWHPcX6S8CQykzVJcRh12jjz4FvD9dnVvrs2foszc884aK",
      "requested_peers_at": "2025-03-21 17:29:27.527",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.529",
      "number_of_peers": null,
      "peer_id": "12D3KooWS83ukWDmgumvoYyDvAy4XuU5DNxVYq9dsSMMkSX5UtJA",
      "requested_peers_at": "2025-03-21 17:29:27.534",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.554",
      "number_of_peers": null,
      "peer_id": "12D3KooWNacj4XXpr6TptJ2UNDTB2ej4Kdmk9EdcfKny8ZvEkuTc",
      "requested_peers_at": "2025-03-21 17:29:27.556",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.561",
      "number_of_peers": null,
      "peer_id": "12D3KooWFkKK7veaU2PPQRivZC1PayRSV3SN4EChvkib6b1kk4a8",
      "requested_peers_at": "2025-03-21 17:29:27.563",
      "response_time (s)": null
    },
    {
      "connected_at": "2025-03-21 17:29:27.572",
      "number_of_peers": null,
      "peer_id": "12D3KooWGTvtjRxCJDMweChG6U9KAQFmGhodKrtHUAuR1bMrRtPz",
      "requested_peers_at": "2025-03-21 17:29:27.574",
      "response_time (s)": null
    }
  ]
}
```

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced network diagnostics with refined peer categorization, now distinguishing several peer types for improved connectivity monitoring.
  - Introduced new capabilities to retrieve and verify distinct groups of peers, supporting more reliable network interactions.
  
- **Refactor**
  - Streamlined diagnostic reporting and connectivity event handling for more efficient performance and clarity in network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->