### PR TITLE
feat: use temporary LWMA instance before change to self

### DIFF
--- a/p2pool/src/sharechain/error.rs
+++ b/p2pool/src/sharechain/error.rs
@@ -43,10 +43,16 @@ pub enum ShareChainError {
     UncleInMainChain { height: u64, hash: FixedHash },
     #[error("Uncle block does not link back to main chain")]
     UncleParentNotInMainChain,
+    #[error("Block contains uncles that are too old")]
+    UncleTooOld,
+    #[error("Block contains uncles on the same height or higher")]
+    UnclesOnSameHeightOrHigher,
     #[error("Block does not have correct total work accumulated")]
     BlockTotalWorkMismatch,
     #[error("Other: {0}")]
     Anyhow(#[from] anyhow::Error),
+    #[error("The Lwma difficulty adjustment algorithm has not been initialized correctly after a reorg")]
+    LwmaNotInitializedCorrectly,
 }
 
 #[derive(Error, Debug)]

--- a/p2pool/src/sharechain/in_memory.rs
+++ b/p2pool/src/sharechain/in_memory.rs
@@ -299,7 +299,11 @@ impl InMemoryShareChain {
         match p2_chain.get_target_difficulty_for_block(block) {
             Some(difficulty) => {
                 if difficulty != block.target_difficulty() && !self.bypass_checks.has_target_difficulty_verified() {
-                    warn!(target: LOG_TARGET, "[{:?}] ❌ Block target difficulty does not match claimed target! Claimed: {:?}, Actual: {:?}", self.pow_algo, block.target_difficulty(), difficulty);
+                    warn!(
+                        target: LOG_TARGET,
+                        "[{:?}] ❌ Block target difficulty does not match claimed target! Claimed: {:?}, Actual: {:?}",
+                        self.pow_algo, block.target_difficulty(), difficulty
+                    );
                     return Err(ValidationError::DifficultyTarget);
                 }
                 // we have validated the target difficulty, so lets set it as valid
@@ -665,8 +669,30 @@ impl ShareChain for InMemoryShareChain {
             PowAlgorithm::Sha3x => Difficulty::from_u64(self.minimum_sha3_target_difficulty).unwrap(),
         };
 
-        let difficulty = chain_read_lock.lwma.get_difficulty().unwrap_or(Difficulty::min());
-        let difficulty = cmp::max(min, difficulty);
+        let difficulty = match chain_read_lock.lwma.get_difficulty() {
+            Some(val) => {
+                if val < min {
+                    debug!(
+                        target: LOG_TARGET,
+                        "[{:?}] Calculated difficulty ({}) too low, using the minimum ({}), likely due to insufficient \
+                        timestamps({})",
+                        self.pow_algo, val, min, !chain_read_lock.lwma.is_full()
+                    );
+                    min
+                } else {
+                    val
+                }
+            },
+            None => {
+                debug!(
+                    target: LOG_TARGET,
+                    "[{:?}] Difficulty could not be calculated, using the minimum, likely due to insufficient \
+                    timestamps({})",
+                    self.pow_algo, !chain_read_lock.lwma.is_full()
+                );
+                Difficulty::min()
+            },
+        };
 
         Ok((res, difficulty))
     }

--- a/p2pool/src/sharechain/in_memory.rs
+++ b/p2pool/src/sharechain/in_memory.rs
@@ -674,9 +674,8 @@ impl ShareChain for InMemoryShareChain {
                 if val < min {
                     debug!(
                         target: LOG_TARGET,
-                        "[{:?}] Calculated difficulty ({}) too low, using the minimum ({}), likely due to insufficient \
-                        timestamps({})",
-                        self.pow_algo, val, min, !chain_read_lock.lwma.is_full()
+                        "[{:?}] Calculated difficulty ({}) too low, using the minimum ({})",
+                        self.pow_algo, val, min
                     );
                     min
                 } else {
@@ -686,9 +685,8 @@ impl ShareChain for InMemoryShareChain {
             None => {
                 debug!(
                     target: LOG_TARGET,
-                    "[{:?}] Difficulty could not be calculated, using the minimum, likely due to insufficient \
-                    timestamps({})",
-                    self.pow_algo, !chain_read_lock.lwma.is_full()
+                    "[{:?}] Difficulty could not be calculated, using the minimum",
+                    self.pow_algo,
                 );
                 Difficulty::min()
             },

--- a/p2pool/src/sharechain/mod.rs
+++ b/p2pool/src/sharechain/mod.rs
@@ -43,8 +43,8 @@ pub const UNCLE_REWARD_SHARE: u64 = 4;
 pub const DIFFICULTY_ADJUSTMENT_WINDOW: usize = 90;
 pub const MEDIAN_TIMESTAMP_WINDOW: usize = 11;
 
-pub const MIN_RANDOMX_DIFFICULTY: u64 = 1_000; // 1 Khs every ten seconds
-pub const MIN_SHA3X_DIFFICULTY: u64 = 100_000_000; // 1 Mhs every ten seconds
+pub const MIN_RANDOMX_DIFFICULTY: u64 = 1_000; // 1 Khs every twenty seconds
+pub const MIN_SHA3X_DIFFICULTY: u64 = 100_000_000; // 1 Mhs twenty ten seconds
 
 pub mod error;
 pub mod in_memory;

--- a/p2pool/src/sharechain/mod.rs
+++ b/p2pool/src/sharechain/mod.rs
@@ -44,7 +44,7 @@ pub const DIFFICULTY_ADJUSTMENT_WINDOW: usize = 90;
 pub const MEDIAN_TIMESTAMP_WINDOW: usize = 11;
 
 pub const MIN_RANDOMX_DIFFICULTY: u64 = 1_000; // 1 Khs every twenty seconds
-pub const MIN_SHA3X_DIFFICULTY: u64 = 100_000_000; // 1 Mhs twenty ten seconds
+pub const MIN_SHA3X_DIFFICULTY: u64 = 100_000_000; // 1 Mhs twenty seconds
 
 pub mod error;
 pub mod in_memory;

--- a/p2pool/src/sharechain/p2block.rs
+++ b/p2pool/src/sharechain/p2block.rs
@@ -107,6 +107,7 @@ impl P2Block {
             .total_pow
             .checked_add_difficulty(target_difficulty)
             .ok_or(ShareChainError::DifficultyOverflow)?;
+        // updates the pow to the newer value, but  we need to subtract the old value
         self.total_pow = self
             .total_pow
             .checked_sub_difficulty(self.target_difficulty)

--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -223,7 +223,7 @@ impl<T: BlockCache> P2Chain<T> {
             bypass_checks,
             params,
         );
-        for block in from_block_cache.all_blocks()? {
+        for (i, block) in from_block_cache.all_blocks()?.into_iter().enumerate() {
             if block.version != PROTOCOL_VERSION {
                 warn!(target: LOG_TARGET, "Block version mismatch, skipping block");
                 continue;
@@ -232,7 +232,9 @@ impl<T: BlockCache> P2Chain<T> {
                 warn!(target: LOG_TARGET, "Block squad mismatch, skipping block");
                 continue;
             }
-            info!(target: LOG_TARGET, "Loading block {}({:x}{:x}{:x}{:x}) into chain", block.height, block.hash[0], block.hash[1], block.hash[2], block.hash[3]);
+            if i % 250 == 0 {
+                info!(target: LOG_TARGET, "Loading block {} into chain", i);
+            }
             let _unused = new_chain.add_block_to_chain(block).inspect_err(|e| {
                 error!(target: LOG_TARGET, "Failed to load block into chain: {}", e);
             });
@@ -516,9 +518,21 @@ impl<T: BlockCache> P2Chain<T> {
                 let mut lwma = LinearWeightedMovingAverage::new(DIFFICULTY_ADJUSTMENT_WINDOW, self.block_time)
                     .expect("Failed to create LWMA");
                 lwma.add_front(block.timestamp, block.target_difficulty);
-                let chain_height = self
-                    .level_at_height(block.height)
-                    .ok_or(ShareChainError::BlockLevelNotFound)?; // Do we need a panic here?
+                let chain_height = match self.level_at_height(block.height) {
+                    None => {
+                        let msg = format!(
+                            "FATAL: LMWA calculation failed while reorging because a block was not found and chain \
+                             data is corrupted. current_block: {:?}, current tip: {:?}",
+                            block.height,
+                            self.get_tip().map(|t| t.height())
+                        );
+                        error!(target: LOG_TARGET, "{}", msg);
+                        // The purpose of the panic here is to clear the memory and force a reload of the chain
+                        // as the database is probably corrupted.
+                        panic!("{}", msg);
+                    },
+                    Some(level) => level,
+                };
                 chain_height.set_chain_block(block.hash);
                 self.cached_shares = None;
                 self.current_tip = block.height;
@@ -543,12 +557,12 @@ impl<T: BlockCache> P2Chain<T> {
                     if current_block.prev_hash != parent_level.chain_block() {
                         match parent_level.get_header(&current_block.prev_hash) {
                             None => {
-                                error!(
-                                    target: LOG_TARGET,
-                                    "FATAL: Reorging (block in chain) failed because parent block was not found and \
-                                    chain data is corrupted."
-                                );
-                                return Err(ShareChainError::BlockNotFound); // Do we need a panic here?
+                                let msg = "FATAL: Reorging (block in chain) failed because parent block was not found \
+                                           and chain data is corrupted.";
+                                error!(target: LOG_TARGET, "{}", msg);
+                                // The purpose of the panic here is to clear the memory and force a reload of the chain
+                                // as the database is probably corrupted.
+                                panic!("{}", msg);
                             },
                             Some(nextblock) => {
                                 let mut_parent_level = self
@@ -563,20 +577,16 @@ impl<T: BlockCache> P2Chain<T> {
                         // we still need more blocks to fill up the lwma
                         match parent_level.get_header(&current_block.prev_hash) {
                             None => {
-                                error!(
-                                    target: LOG_TARGET,
-                                    "FATAL: Reorging (block not in chain) failed because parent block was not found and \
-                                    chain data is corrupted."
-                                );
-                                // The purpose of the panic here is to clear the memory and force a reload of the chain
-                                // as the database is probably corrupted.
-                                panic!(
-                                    "FATAL: Could not calculate LMWA while reorging (block in chain) failed because \
-                                     parent block was not found and chain data is corrupted. current_block: {:?}, \
-                                     current tip: {:?}",
+                                let msg = format!(
+                                    "FATAL: Reorging (block not in chain) failed because parent block was not found \
+                                     and chain data is corrupted. current_block: {:?}, current tip: {:?}",
                                     current_block.height,
                                     self.get_tip().map(|t| t.height())
                                 );
+                                error!(target: LOG_TARGET, "{}", msg);
+                                // The purpose of the panic here is to clear the memory and force a reload of the chain
+                                // as the database is probably corrupted.
+                                panic!("{}", msg);
                             },
                             Some(nextblock) => {
                                 current_block = nextblock.clone();
@@ -637,22 +647,22 @@ impl<T: BlockCache> P2Chain<T> {
         let block = level.get(&hash).ok_or(ShareChainError::BlockNotFound)?;
         let mut verified = block.verified;
 
-        info!(target: LOG_TARGET, "Verifying parents and pow: {}", height);
+        debug!(target: LOG_TARGET, "Verifying parents and pow: {}", height);
         if self.verify_pow_and_parents(block.clone())? {
             verified.set_has_parents();
-            info!(target: LOG_TARGET, "Verified parents and pow");
+            debug!(target: LOG_TARGET, "Verified parents and pow");
         }
 
-        info!(target: LOG_TARGET, "Verifying difficulty: {}", height);
+        debug!(target: LOG_TARGET, "Verifying difficulty: {}", height);
         if self.verify_difficulty(block.clone())? {
             verified.set_difficulty_verified();
-            info!(target: LOG_TARGET, "Verified difficulty");
+            debug!(target: LOG_TARGET, "Verified difficulty");
         }
 
-        info!(target: LOG_TARGET, "Verifying target difficulty: {}", height);
+        debug!(target: LOG_TARGET, "Verifying target difficulty: {}", height);
         if self.verify_target_difficulty(block.clone())? {
             verified.set_target_difficulty_verified();
-            info!(target: LOG_TARGET, "Verified target difficulty");
+            debug!(target: LOG_TARGET, "Verified target difficulty");
         }
 
         // info!(target: LOG_TARGET, "Verifying median timestamp: {}", height);
@@ -660,10 +670,10 @@ impl<T: BlockCache> P2Chain<T> {
             verified.set_median_timestamp();
         }
 
-        info!(target: LOG_TARGET, "Verifying shares");
+        debug!(target: LOG_TARGET, "Verifying shares");
         if self.verify_shares_for_block(block.clone())? {
             verified.set_correct_shares();
-            info!(target: LOG_TARGET, "Verified shares");
+            debug!(target: LOG_TARGET, "Verified shares");
         }
 
         // lets update verification status
@@ -870,14 +880,22 @@ impl<T: BlockCache> P2Chain<T> {
             let uncle_level = match self.level_at_height(uncle.0) {
                 Some(level) => level,
                 None => {
-                    warn!(target: LOG_TARGET, "[{:?}] ❌ Could not get uncle level of new tip block in calculating shares", block.original_header.pow.pow_algo);
+                    trace!(
+                        target: LOG_TARGET,
+                        "[{:?}] ❌ Could not get uncle level of new tip block in calculating shares",
+                        block.original_header.pow.pow_algo
+                    );
                     return Ok(false);
                 },
             };
             let uncle_block = match uncle_level.get(&uncle.1) {
                 Some(block) => block.clone(),
                 None => {
-                    warn!(target: LOG_TARGET, "[{:?}] ❌ Could not get uncle block of new tip block in calculating shares", block.original_header.pow.pow_algo);
+                    trace!(
+                        target: LOG_TARGET,
+                        "[{:?}] ❌ Could not get uncle block of new tip block in calculating shares",
+                        block.original_header.pow.pow_algo
+                    );
                     return Ok(false);
                 },
             };
@@ -980,9 +998,8 @@ impl<T: BlockCache> P2Chain<T> {
                 None => {
                     debug!(
                         target: LOG_TARGET,
-                        "[{:?}] Difficulty could not be calculated, using the minimum, likely due to insufficient \
-                        timestamps({})",
-                        block.original_header.pow.pow_algo, !self.lwma.is_full()
+                        "[{:?}] Difficulty could not be calculated, using the minimum",
+                        block.original_header.pow.pow_algo
                     );
                     Difficulty::min()
                 },
@@ -1131,18 +1148,17 @@ impl<T: BlockCache> P2Chain<T> {
         let start_level = match self.level_at_height(calculating_height) {
             Some(level) => level,
             None => {
-                warn!(target: LOG_TARGET, "❌ No level at height: {}", calculating_height);
+                debug!(target: LOG_TARGET, "❌ No start level at height: {}", calculating_height);
                 return Ok(miners_to_shares);
             },
         };
 
-        // we want to count 1 short,as the final share will be for this node
+        // we want to count 1 short, as the final share will be for this node
         let stop_height = start_level.height().saturating_sub(self.share_window - 1);
-        debug!(target: LOG_TARGET, "Stop level: {}", stop_height);
         let mut cur_block = start_level
             .get_header(prev_hash)
             .ok_or(ShareChainError::BlockNotFound)
-            .inspect_err(|_| warn!(target: LOG_TARGET, "❌ start block not found"))?;
+            .inspect_err(|_| debug!(target: LOG_TARGET, "❌ No start level at height: {}", prev_hash))?;
         update_insert(
             &mut miners_to_shares,
             cur_block.wallet_address,
@@ -1153,10 +1169,14 @@ impl<T: BlockCache> P2Chain<T> {
             let uncle_block = self
                 .level_at_height(uncle.0)
                 .ok_or(ShareChainError::UncleBlockNotFound)
-                .inspect_err(|_| warn!(target: LOG_TARGET, "❌start uncle level not found"))?
+                .inspect_err(|_| debug!(target: LOG_TARGET, "❌ Start uncle level '{}' not found", uncle.0))?
                 .get_header(&uncle.1)
                 .ok_or(ShareChainError::UncleBlockNotFound)
-                .inspect_err(|_| warn!(target: LOG_TARGET, "❌start uncle block not found"))?;
+                .inspect_err(|_| {
+                    debug!(
+                        target: LOG_TARGET, "❌ Start uncle block '{}' at height '{}' not found", uncle.1, uncle.0
+                    )
+                })?;
             update_insert(
                 &mut miners_to_shares,
                 uncle_block.wallet_address,
@@ -1169,13 +1189,17 @@ impl<T: BlockCache> P2Chain<T> {
                 .level_at_height(cur_block.height.saturating_sub(1))
                 .ok_or(ShareChainError::BlockNotFound)
                 .inspect_err(
-                    |_| warn!(target: LOG_TARGET, "❌ No level at height: {}", cur_block.height.saturating_sub(1)),
+                    |_| debug!(target: LOG_TARGET, "❌ No level at height: {}", cur_block.height.saturating_sub(1)),
                 )?
                 .get_header(&cur_block.prev_hash)
                 .ok_or(ShareChainError::BlockNotFound)
-                .inspect_err(
-                    |_| warn!(target: LOG_TARGET, "❌ No block at height: {}", cur_block.height.saturating_sub(1)),
-                )?;
+                .inspect_err(|_| {
+                    debug!(
+                        target: LOG_TARGET,
+                        "❌ Block '{}' at height '{}' not found",
+                        cur_block.height.saturating_sub(1), cur_block.prev_hash
+                    )
+                })?;
             update_insert(
                 &mut miners_to_shares,
                 cur_block.wallet_address,
@@ -1186,10 +1210,14 @@ impl<T: BlockCache> P2Chain<T> {
                 let uncle_block = self
                     .level_at_height(uncle.0)
                     .ok_or(ShareChainError::UncleBlockNotFound)
-                    .inspect_err(|_| warn!(target: LOG_TARGET, "❌ No uncle level at height: {}", uncle.0))?
+                    .inspect_err(|_| debug!(target: LOG_TARGET, "❌ No uncle level at height: {}", uncle.0))?
                     .get_header(&uncle.1)
                     .ok_or(ShareChainError::UncleBlockNotFound)
-                    .inspect_err(|_| warn!(target: LOG_TARGET, "❌ No uncle block at height: {}", uncle.0))?;
+                    .inspect_err(|_| {
+                        debug!(
+                            target: LOG_TARGET, "❌ Block '{}' at height '{}' not found", uncle.1, uncle.0
+                        )
+                    })?;
                 update_insert(
                     &mut miners_to_shares,
                     uncle_block.wallet_address,

--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -568,6 +568,8 @@ impl<T: BlockCache> P2Chain<T> {
                                     "FATAL: Reorging (block not in chain) failed because parent block was not found and \
                                     chain data is corrupted."
                                 );
+                                // The purpose of the panic here is to clear the memory and force a reload of the chain
+                                // as the database is probably corrupted.
                                 panic!(
                                     "FATAL: Could not calculate LMWA while reorging (block in chain) failed because \
                                      parent block was not found and chain data is corrupted. current_block: {:?}, \
@@ -1136,7 +1138,7 @@ impl<T: BlockCache> P2Chain<T> {
 
         // we want to count 1 short,as the final share will be for this node
         let stop_height = start_level.height().saturating_sub(self.share_window - 1);
-        warn!(target: LOG_TARGET, "❌ stop level: {}", stop_height);
+        debug!(target: LOG_TARGET, "Stop level: {}", stop_height);
         let mut cur_block = start_level
             .get_header(prev_hash)
             .ok_or(ShareChainError::BlockNotFound)

--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -223,8 +223,7 @@ impl<T: BlockCache> P2Chain<T> {
             bypass_checks,
             params,
         );
-
-        for (i, block) in from_block_cache.all_blocks()?.into_iter().enumerate() {
+        for block in from_block_cache.all_blocks()? {
             if block.version != PROTOCOL_VERSION {
                 warn!(target: LOG_TARGET, "Block version mismatch, skipping block");
                 continue;
@@ -233,10 +232,7 @@ impl<T: BlockCache> P2Chain<T> {
                 warn!(target: LOG_TARGET, "Block squad mismatch, skipping block");
                 continue;
             }
-            debug!(target: LOG_TARGET, "Loading block {}({:x}{:x}{:x}{:x}) into chain", block.height, block.hash[0], block.hash[1], block.hash[2], block.hash[3]);
-            if i % 250 == 0 {
-                info!(target: LOG_TARGET, "Loading block {} into chain", i);
-            }
+            info!(target: LOG_TARGET, "Loading block {}({:x}{:x}{:x}{:x}) into chain", block.height, block.hash[0], block.hash[1], block.hash[2], block.hash[3]);
             let _unused = new_chain.add_block_to_chain(block).inspect_err(|e| {
                 error!(target: LOG_TARGET, "Failed to load block into chain: {}", e);
             });
@@ -416,7 +412,11 @@ impl<T: BlockCache> P2Chain<T> {
 
         if self.get_tip().is_some() && self.get_tip().unwrap().chain_block() == block.prev_hash {
             // easy this builds on the tip
-            info!(target: LOG_TARGET, "[{:?}] New block added to tip, and is now the new tip: {:?}:{}", algo, new_block_height, &block.hash.to_hex()[0..8]);
+            info!(
+                target: LOG_TARGET,
+                "[{:?}] New block added to tip, and is now the new tip: {:?}:{}",
+                algo, new_block_height, &block.hash.to_hex()[0..8]
+            );
             for uncle in &block.uncles {
                 let uncle_block = self
                     .get_block_at_height(uncle.0, &uncle.1)
@@ -492,7 +492,6 @@ impl<T: BlockCache> P2Chain<T> {
                 if level.chain_block() == current_counting_block.hash {
                     break;
                 }
-                // we can unwrap as we now the parent exists
                 current_counting_block = self
                     .get_block_header_at_height(
                         current_counting_block.height.saturating_sub(1),
@@ -514,12 +513,12 @@ impl<T: BlockCache> P2Chain<T> {
                 new_tip.set_new_tip(hash, new_block_height);
                 // we need to reorg the chain
                 // lets start by resetting the lwma
-                self.lwma = LinearWeightedMovingAverage::new(DIFFICULTY_ADJUSTMENT_WINDOW, self.block_time)
+                let mut lwma = LinearWeightedMovingAverage::new(DIFFICULTY_ADJUSTMENT_WINDOW, self.block_time)
                     .expect("Failed to create LWMA");
-                self.lwma.add_front(block.timestamp, block.target_difficulty);
+                lwma.add_front(block.timestamp, block.target_difficulty);
                 let chain_height = self
                     .level_at_height(block.height)
-                    .ok_or(ShareChainError::BlockLevelNotFound)?;
+                    .ok_or(ShareChainError::BlockLevelNotFound)?; // Do we need a panic here?
                 chain_height.set_chain_block(block.hash);
                 self.cached_shares = None;
                 self.current_tip = block.height;
@@ -527,7 +526,9 @@ impl<T: BlockCache> P2Chain<T> {
                 // lets first go up and reset all chain block links
                 let mut current_height = block.height;
                 while self.level_at_height(current_height.saturating_add(1)).is_some() {
-                    let mut_child_level = self.level_at_height(current_height.saturating_add(1)).unwrap();
+                    let mut_child_level = self
+                        .level_at_height(current_height.saturating_add(1))
+                        .expect("wil not fail");
                     mut_child_level.set_chain_block(FixedHash::zero());
                     current_height += 1;
                 }
@@ -536,43 +537,50 @@ impl<T: BlockCache> P2Chain<T> {
                 let mut counter = 1;
                 while self.level_at_height(current_block.height.saturating_sub(1)).is_some() {
                     counter += 1;
-                    let parent_level = self.level_at_height(current_block.height.saturating_sub(1)).unwrap();
+                    let parent_level = self
+                        .level_at_height(current_block.height.saturating_sub(1))
+                        .expect("wil not fail");
                     if current_block.prev_hash != parent_level.chain_block() {
-                        // safety check
-                        let nextblock = parent_level.get_header(&current_block.prev_hash);
-                        if nextblock.is_none() {
-                            error!(target: LOG_TARGET, "FATAL: Reorging (block in chain) failed because parent block was not found and chain data is corrupted.");
-                            return Err(ShareChainError::BlockNotFound);
-                            // panic!(
-                            //     "FATAL: Reorging (block in chain) failed because parent block was not found and chain
-                            // \      data is corrupted. current_block: {:?}, current tip:
-                            // {:?}",     current_block.height,
-                            //     self.get_tip().map(|t| t.height())
-                            // );
+                        match parent_level.get_header(&current_block.prev_hash) {
+                            None => {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "FATAL: Reorging (block in chain) failed because parent block was not found and \
+                                    chain data is corrupted."
+                                );
+                                return Err(ShareChainError::BlockNotFound); // Do we need a panic here?
+                            },
+                            Some(nextblock) => {
+                                let mut_parent_level = self
+                                    .level_at_height(current_block.height.saturating_sub(1))
+                                    .expect("wil not fail");
+                                mut_parent_level.set_chain_block(current_block.prev_hash);
+                                current_block = nextblock.clone();
+                                lwma.add_front(current_block.timestamp, current_block.target_difficulty);
+                            },
                         }
-                        // fix the main chain
-                        let mut_parent_level = self.level_at_height(current_block.height.saturating_sub(1)).unwrap();
-                        mut_parent_level.set_chain_block(current_block.prev_hash);
-                        current_block = nextblock.unwrap().clone();
-                        self.lwma
-                            .add_front(current_block.timestamp, current_block.target_difficulty);
-                    } else if !self.lwma.is_full() {
+                    } else if !lwma.is_full() {
                         // we still need more blocks to fill up the lwma
-                        let nextblock = parent_level.get_header(&current_block.prev_hash);
-                        if nextblock.is_none() {
-                            error!(target: LOG_TARGET, "FATAL: Reorging (block not in chain) failed because parent block was not found and chain data is corrupted.");
-                            panic!(
-                                "FATAL: Could not calculate LMWA while reorging (block in chain) failed because \
-                                 parent block was not found and chain data is corrupted. current_block: {:?}, current \
-                                 tip: {:?}",
-                                current_block.height,
-                                self.get_tip().map(|t| t.height())
-                            );
+                        match parent_level.get_header(&current_block.prev_hash) {
+                            None => {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "FATAL: Reorging (block not in chain) failed because parent block was not found and \
+                                    chain data is corrupted."
+                                );
+                                panic!(
+                                    "FATAL: Could not calculate LMWA while reorging (block in chain) failed because \
+                                     parent block was not found and chain data is corrupted. current_block: {:?}, \
+                                     current tip: {:?}",
+                                    current_block.height,
+                                    self.get_tip().map(|t| t.height())
+                                );
+                            },
+                            Some(nextblock) => {
+                                current_block = nextblock.clone();
+                                lwma.add_front(current_block.timestamp, current_block.target_difficulty);
+                            },
                         }
-
-                        current_block = nextblock.unwrap().clone();
-                        self.lwma
-                            .add_front(current_block.timestamp, current_block.target_difficulty);
                     } else {
                         break;
                     }
@@ -582,6 +590,7 @@ impl<T: BlockCache> P2Chain<T> {
                         break;
                     }
                 }
+                self.lwma = lwma;
             }
         }
 
@@ -626,24 +635,33 @@ impl<T: BlockCache> P2Chain<T> {
         let block = level.get(&hash).ok_or(ShareChainError::BlockNotFound)?;
         let mut verified = block.verified;
 
+        info!(target: LOG_TARGET, "Verifying parents and pow: {}", height);
         if self.verify_pow_and_parents(block.clone())? {
             verified.set_has_parents();
+            info!(target: LOG_TARGET, "Verified parents and pow");
         }
 
+        info!(target: LOG_TARGET, "Verifying difficulty: {}", height);
         if self.verify_difficulty(block.clone())? {
             verified.set_difficulty_verified();
+            info!(target: LOG_TARGET, "Verified difficulty");
         }
 
+        info!(target: LOG_TARGET, "Verifying target difficulty: {}", height);
         if self.verify_target_difficulty(block.clone())? {
             verified.set_target_difficulty_verified();
+            info!(target: LOG_TARGET, "Verified target difficulty");
         }
 
+        // info!(target: LOG_TARGET, "Verifying median timestamp: {}", height);
         if self.verify_median_timestamp_for_block(block.clone())? {
             verified.set_median_timestamp();
         }
 
+        info!(target: LOG_TARGET, "Verifying shares");
         if self.verify_shares_for_block(block.clone())? {
             verified.set_correct_shares();
+            info!(target: LOG_TARGET, "Verified shares");
         }
 
         // lets update verification status
@@ -685,7 +703,11 @@ impl<T: BlockCache> P2Chain<T> {
         }
 
         if block.total_pow() != total_work {
-            warn!(target: LOG_TARGET, "❌ Block accumulated difficulty does not match claimed pow! Claimed: {:?}, Actual: {:?}", block.total_pow(), total_work);
+            warn!(
+                target: LOG_TARGET,
+                "❌ Block accumulated difficulty does not match claimed pow! Claimed: {:?}, Actual: {:?}",
+                block.total_pow(), total_work
+            );
             return Err(ShareChainError::ValidationError(ValidationError::DifficultyTarget));
         }
         Ok(true)
@@ -714,7 +736,11 @@ impl<T: BlockCache> P2Chain<T> {
             PowAlgorithm::Sha3x => sha3x_difficulty(&block.original_header).map_err(ValidationError::Difficulty)?,
         };
         if curr_difficulty < block.target_difficulty() && !self.bypass_checks.has_difficulty_verified() {
-            warn!(target: LOG_TARGET, "[{:?}] ❌ Claimed difficulty is too low! Claimed: {:?}, Actual: {:?}", pow_algo, block.target_difficulty(), curr_difficulty);
+            warn!(
+                target: LOG_TARGET,
+                "[{:?}] ❌ Claimed difficulty is too low! Claimed: {:?}, Actual: {:?}",
+                pow_algo, block.target_difficulty(), curr_difficulty
+            );
             return Ok(false);
         }
         Ok(true)
@@ -727,7 +753,11 @@ impl<T: BlockCache> P2Chain<T> {
         match self.get_target_difficulty_for_block(&block) {
             Some(difficulty) => {
                 if difficulty != block.target_difficulty() {
-                    warn!(target: LOG_TARGET, "[{:?}] ❌ Block target difficulty does not match claimed target! Claimed: {:?}, Actual: {:?}", block.original_header.pow.pow_algo, block.target_difficulty(), difficulty);
+                    warn!(
+                        target: LOG_TARGET,
+                        "[{:?}] ❌ Block target difficulty does not match claimed target! Claimed: {:?}, Actual: {:?}",
+                        block.original_header.pow.pow_algo, block.target_difficulty(), difficulty
+                    );
                     return Ok(false);
                 }
             },
@@ -801,6 +831,7 @@ impl<T: BlockCache> P2Chain<T> {
     // technically is due to optimizations, but the hash is only calculated from the point, which is not mutable. So
     // this is safe
     #[allow(clippy::mutable_key_type)]
+    #[allow(clippy::too_many_lines)]
     pub fn verify_shares_for_block(&self, block: Arc<P2Block>) -> Result<bool, ShareChainError> {
         if block.verified.has_correct_shares() || self.bypass_checks.has_correct_shares() || block.height == 0 {
             return Ok(true);
@@ -836,11 +867,17 @@ impl<T: BlockCache> P2Chain<T> {
         for uncle in &block.uncles {
             let uncle_level = match self.level_at_height(uncle.0) {
                 Some(level) => level,
-                None => return Ok(false),
+                None => {
+                    warn!(target: LOG_TARGET, "[{:?}] ❌ Could not get uncle level of new tip block in calculating shares", block.original_header.pow.pow_algo);
+                    return Ok(false);
+                },
             };
             let uncle_block = match uncle_level.get(&uncle.1) {
                 Some(block) => block.clone(),
-                None => return Ok(false),
+                None => {
+                    warn!(target: LOG_TARGET, "[{:?}] ❌ Could not get uncle block of new tip block in calculating shares", block.original_header.pow.pow_algo);
+                    return Ok(false);
+                },
             };
             let miner_share = MinerShare {
                 miner: uncle_block.miner_wallet_address.clone(),
@@ -872,7 +909,11 @@ impl<T: BlockCache> P2Chain<T> {
             let spend_key = if let Some(Opcode::PushPubKey(spend_key)) = output.script.opcode(0) {
                 spend_key
             } else {
-                warn!(target: LOG_TARGET, "[{:?}] ❌ Wrong coinbase script, found: {}", block.original_header.pow.pow_algo, output.script);
+                warn!(
+                    target: LOG_TARGET,
+                    "[{:?}] ❌ Wrong coinbase script, found: {}",
+                    block.original_header.pow.pow_algo, output.script
+                );
                 return Err(ShareChainError::ValidationError(ValidationError::InvalidCoinbase));
             };
             match miners_shares.get(spend_key) {
@@ -887,16 +928,31 @@ impl<T: BlockCache> P2Chain<T> {
                     // We do this as it might be the order of output generation is different, and it might be that a few
                     // outputs are a few micro tari off due to division as its not always possible to divide exactly
                     if value < output_value.saturating_sub(10) || value > output_value.saturating_add(10) {
-                        warn!(target: LOG_TARGET, "[{:?}] ❌ Wrong coinbase value for {}, expected: {}, found: {}", block.original_header.pow.pow_algo, spend_key, value, output_value);
+                        warn!(
+                            target: LOG_TARGET,
+                            "[{:?}] ❌ Wrong coinbase value for {}, expected: {}, found: {}",
+                            block.original_header.pow.pow_algo, spend_key, value, output_value
+                        );
                         return Err(ShareChainError::ValidationError(ValidationError::InvalidCoinbase));
                     }
                     if miner_share.coinbase_extra != *output.features.coinbase_extra {
-                        warn!(target: LOG_TARGET, "[{:?}] ❌ Coinbase extra mismatch for {}, expected: {:?}, found {:?}", block.original_header.pow.pow_algo, spend_key, output.features.coinbase_extra,  miner_share.coinbase_extra);
+                        warn!(
+                            target: LOG_TARGET,
+                            "[{:?}] ❌ Coinbase extra mismatch for {}, expected: {:?}, found {:?}",
+                            block.original_header.pow.pow_algo,
+                            spend_key,
+                            output.features.coinbase_extra,
+                            miner_share.coinbase_extra
+                        );
                         return Err(ShareChainError::ValidationError(ValidationError::InvalidCoinbase));
                     }
                 },
                 None => {
-                    warn!(target: LOG_TARGET, "[{:?}] ❌ Coinbase not found for share: {}", block.original_header.pow.pow_algo, spend_key);
+                    warn!(
+                        target: LOG_TARGET,
+                        "[{:?}] ❌ Coinbase not found for share: {}",
+                        block.original_header.pow.pow_algo, spend_key
+                    );
                     return Err(ShareChainError::ValidationError(ValidationError::InvalidCoinbase));
                 },
             }
@@ -917,7 +973,18 @@ impl<T: BlockCache> P2Chain<T> {
                 PowAlgorithm::Sha3x => Difficulty::from_u64(self.minimum_sha3_target_difficulty).unwrap(),
             };
 
-            let difficulty = self.lwma.get_difficulty().unwrap_or(Difficulty::min());
+            let difficulty = match self.lwma.get_difficulty() {
+                Some(val) => val,
+                None => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "[{:?}] Difficulty could not be calculated, using the minimum, likely due to insufficient \
+                        timestamps({})",
+                        block.original_header.pow.pow_algo, !self.lwma.is_full()
+                    );
+                    Difficulty::min()
+                },
+            };
 
             return Some(cmp::max(min, difficulty));
         }
@@ -944,7 +1011,19 @@ impl<T: BlockCache> P2Chain<T> {
                 break;
             }
         }
-        Some(lwma.get_difficulty().unwrap_or(Difficulty::min()))
+        let difficulty = match lwma.get_difficulty() {
+            Some(val) => val,
+            None => {
+                debug!(
+                    target: LOG_TARGET,
+                    "[{:?}] Difficulty could not be calculated, using the minimum",
+                    block.original_header.pow.pow_algo
+                );
+                Difficulty::min()
+            },
+        };
+
+        Some(difficulty)
     }
 
     fn add_block_inner(&mut self, block: Arc<P2Block>) -> Result<ChainAddResult, ShareChainError> {
@@ -1049,14 +1128,19 @@ impl<T: BlockCache> P2Chain<T> {
         }
         let start_level = match self.level_at_height(calculating_height) {
             Some(level) => level,
-            None => return Ok(miners_to_shares),
+            None => {
+                warn!(target: LOG_TARGET, "❌ No level at height: {}", calculating_height);
+                return Ok(miners_to_shares);
+            },
         };
 
         // we want to count 1 short,as the final share will be for this node
         let stop_height = start_level.height().saturating_sub(self.share_window - 1);
+        warn!(target: LOG_TARGET, "❌ stop level: {}", stop_height);
         let mut cur_block = start_level
             .get_header(prev_hash)
-            .ok_or(ShareChainError::BlockNotFound)?;
+            .ok_or(ShareChainError::BlockNotFound)
+            .inspect_err(|_| warn!(target: LOG_TARGET, "❌ start block not found"))?;
         update_insert(
             &mut miners_to_shares,
             cur_block.wallet_address,
@@ -1066,9 +1150,11 @@ impl<T: BlockCache> P2Chain<T> {
         for uncle in &cur_block.uncles {
             let uncle_block = self
                 .level_at_height(uncle.0)
-                .ok_or(ShareChainError::UncleBlockNotFound)?
+                .ok_or(ShareChainError::UncleBlockNotFound)
+                .inspect_err(|_| warn!(target: LOG_TARGET, "❌start uncle level not found"))?
                 .get_header(&uncle.1)
-                .ok_or(ShareChainError::UncleBlockNotFound)?;
+                .ok_or(ShareChainError::UncleBlockNotFound)
+                .inspect_err(|_| warn!(target: LOG_TARGET, "❌start uncle block not found"))?;
             update_insert(
                 &mut miners_to_shares,
                 uncle_block.wallet_address,
@@ -1079,9 +1165,15 @@ impl<T: BlockCache> P2Chain<T> {
         while cur_block.height > stop_height {
             cur_block = self
                 .level_at_height(cur_block.height.saturating_sub(1))
-                .ok_or(ShareChainError::BlockNotFound)?
+                .ok_or(ShareChainError::BlockNotFound)
+                .inspect_err(
+                    |_| warn!(target: LOG_TARGET, "❌ No level at height: {}", cur_block.height.saturating_sub(1)),
+                )?
                 .get_header(&cur_block.prev_hash)
-                .ok_or(ShareChainError::BlockNotFound)?;
+                .ok_or(ShareChainError::BlockNotFound)
+                .inspect_err(
+                    |_| warn!(target: LOG_TARGET, "❌ No block at height: {}", cur_block.height.saturating_sub(1)),
+                )?;
             update_insert(
                 &mut miners_to_shares,
                 cur_block.wallet_address,
@@ -1091,9 +1183,11 @@ impl<T: BlockCache> P2Chain<T> {
             for uncle in &cur_block.uncles {
                 let uncle_block = self
                     .level_at_height(uncle.0)
-                    .ok_or(ShareChainError::UncleBlockNotFound)?
+                    .ok_or(ShareChainError::UncleBlockNotFound)
+                    .inspect_err(|_| warn!(target: LOG_TARGET, "❌ No uncle level at height: {}", uncle.0))?
                     .get_header(&uncle.1)
-                    .ok_or(ShareChainError::UncleBlockNotFound)?;
+                    .ok_or(ShareChainError::UncleBlockNotFound)
+                    .inspect_err(|_| warn!(target: LOG_TARGET, "❌ No uncle block at height: {}", uncle.0))?;
                 update_insert(
                     &mut miners_to_shares,
                     uncle_block.wallet_address,

--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -577,6 +577,10 @@ impl<T: BlockCache> P2Chain<T> {
                         // we still need more blocks to fill up the lwma
                         match parent_level.get_header(&current_block.prev_hash) {
                             None => {
+                                if current_block.height == 0 {
+                                    // edge case we are at the start of the chain
+                                    break;
+                                }
                                 let msg = format!(
                                     "FATAL: Reorging (block not in chain) failed because parent block was not found \
                                      and chain data is corrupted. current_block: {:?}, current tip: {:?}",

--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -1118,6 +1118,7 @@ impl<T: BlockCache> P2Chain<T> {
     // technically is due to optimizations, but the hash is only calculated from the point, which is not mutable. So
     // this is safe
     #[allow(clippy::mutable_key_type)]
+    #[allow(clippy::too_many_lines)]
     pub fn get_calculate_and_cache_hashmap_of_shares(
         &self,
         calculating_height: u64,


### PR DESCRIPTION
Description
---
- Used a temporary LWMA instance at reorg until it could be populated fully, then affected the change to self.
- Improved difficulty calculation logs.
- Various formatting changes in log macros where `cargo format` does not reach.

In collaboration with https://github.com/SWvheerden.

Motivation and Context
---

How Has This Been Tested?
---
System-level tests syncing from scratch

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error variants for enhanced error handling related to uncle blocks and difficulty adjustments.

- **Refactor**
	- Expanded and refined error handling, providing more specific notifications for conditions related to uncle blocks and difficulty initialization.
	- Improved logging clarity and updated block difficulty computation, streamlining processing and enhancing troubleshooting information.
	- Simplified loop structures and enhanced logging formats for improved readability.

- **Documentation**
	- Clarified performance guidelines by updating descriptions for minimum difficulty levels to reflect twenty-second intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->