### PR TITLE
chore: add all blocks back in

### DIFF
--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -245,8 +245,8 @@ impl<T: BlockCache> P2Chain<T> {
                 continue;
             }
 
-            // We need to add this back in when uncle blocks can be verified and here we can check that they are verified for being uncles
-            // if !block.verified.is_verified() {
+            // We need to add this back in when uncle blocks can be verified and here we can check that they are
+            // verified for being uncles if !block.verified.is_verified() {
             //     warn!(target: LOG_TARGET, "Block not verified, skipping block");
             //     continue;
             // }

--- a/p2pool/src/sharechain/p2chain.rs
+++ b/p2pool/src/sharechain/p2chain.rs
@@ -244,10 +244,12 @@ impl<T: BlockCache> P2Chain<T> {
                 warn!(target: LOG_TARGET, "Block squad mismatch, skipping block");
                 continue;
             }
-            if !block.verified.is_verified() {
-                warn!(target: LOG_TARGET, "Block not verified, skipping block");
-                continue;
-            }
+
+            // We need to add this back in when uncle blocks can be verified and here we can check that they are verified for being uncles
+            // if !block.verified.is_verified() {
+            //     warn!(target: LOG_TARGET, "Block not verified, skipping block");
+            //     continue;
+            // }
 
             if block.timestamp < earliest_date {
                 warn!(target: LOG_TARGET, "Block too old, skipping block");


### PR DESCRIPTION
Description
---
We dont want to add unverified blocks into the chain, but uncle blocks are not verified atm, and we do need them for the shares, so this temp patches it to be not removed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Adjusted the block verification process, allowing for a broader range of blocks to be processed during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->