### PR TITLE
feat: change peer propegation

### DIFF
--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -2664,7 +2664,7 @@ where S: ShareChain
                                     AddPeerStatus::NonSquad => non_squad_peers.push(*peer),
                                     _ => {
                                         if let Some(record) = store_write_lock.get(peer){
-                                            squad_peers.push((*peer, record.peer_info.current_sha3x_height, record.peer_info.current_random_x_height))
+                                            squad_peers.push(record.clone())
                                         }
                                     }
                                 }
@@ -2705,18 +2705,18 @@ where S: ShareChain
                         }
 
                         // lets trim some connection, this will bring the connections down to a min of 5
-                        while squad_peers.len() > 6{
+                        while squad_peers.len() > MAX_OUTBOUND_SQUAD_PEERS.saturating_sub(2){
                             // we remove one sha3 and one rx
                             squad_peers.sort_by(|a, b| {
-                                a.1.cmp(&b.1)
+                                b.peer_info.current_sha3x_pow.cmp(&a.peer_info.current_sha3x_pow)
                             });
-                            let peer_id = squad_peers.remove(squad_peers.len() / 2);
-                            let _ = self.swarm.disconnect_peer_id(peer_id.0);
+                            let peer_id = squad_peers.remove(squad_peers.len());
+                            let _ = self.swarm.disconnect_peer_id(peer_id.peer_id);
                             squad_peers.sort_by(|a, b| {
-                                a.2.cmp(&b.2)
+                                b.peer_info.current_random_x_pow.cmp(&a.peer_info.current_random_x_pow)
                             });
-                            let peer_id = squad_peers.remove(squad_peers.len() / 2);
-                            let _ = self.swarm.disconnect_peer_id(peer_id.0);
+                            let peer_id = squad_peers.remove(squad_peers.len());
+                            let _ = self.swarm.disconnect_peer_id(peer_id.peer_id);
                         }
 
 
@@ -2860,7 +2860,6 @@ where S: ShareChain
             }
         }
     }
-
 
     async fn get_same_squad_peer_records(&self, filter_peers: &[PeerId], is_relay: bool) -> Vec<PeerStoreRecord> {
         let network_peer_store = self.network_peer_store.read().await;

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -114,6 +114,7 @@ const NUM_PEERS_TO_META_DATA_EXCHANGE: usize = 8;
 const NUM_PEERS_TO_PEER_INFO_EXCHANGE: usize = 8;
 const MAX_OUTBOUND_SQUAD_PEERS: usize = 8;
 const MAX_OUTBOUND_NON_SQUAD_PEERS: usize = 2;
+const CONNECTION_CHURN_DELAY_SECS: u64 = 60 * 20; // 20 minutes
 
 #[derive(Clone, Debug)]
 #[allow(clippy::struct_excessive_bools)]
@@ -2602,6 +2603,9 @@ where S: ShareChain
         let mut seek_connections_interval = tokio::time::interval(Duration::from_secs(20));
         seek_connections_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+        let mut connection_churn_interval = tokio::time::interval(Duration::from_secs(CONNECTION_CHURN_DELAY_SECS));
+        connection_churn_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
         let mut debug_chain_graph = if self.config.debug_print_chain {
             tokio::time::interval(Duration::from_secs(60))
         } else {
@@ -2618,6 +2622,7 @@ where S: ShareChain
         tokio::pin!(peer_exchange_interval);
         tokio::pin!(connection_stats_publish);
         tokio::pin!(seek_connections_interval);
+        tokio::pin!(connection_churn_interval);
 
         let uptime = Instant::now();
         loop {
@@ -2635,6 +2640,59 @@ where S: ShareChain
                     }
                     if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
                         warn!(target: LOG_TARGET, "Query handling took too long: {:?}", timer.elapsed());
+                    }
+                },
+                _ = connection_churn_interval.tick() => {
+                    let timer = Instant::now();
+                    if !self.config.is_seed_peer {
+
+                        let store_read_lock = self.network_peer_store.read().await;
+
+                        let mut squad_peers = Vec::new();
+                        let mut non_squad_peers = Vec::new();
+
+                        for peer in self.swarm.connected_peers(){
+                            if let Some(peer_type) = store_read_lock.peer_type(peer){
+                                match peer_type{
+                                    AddPeerStatus::NonSquad => non_squad_peers.push(*peer),
+                                    _ => {
+                                        if let Some(record) = store_read_lock.get(peer){
+                                            squad_peers.push(record.clone())
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        while non_squad_peers.len() > 1 {
+                            let peer_id = non_squad_peers.pop().expect("should be able to pop peer");
+                            debug!(target: LOG_TARGET, "Disconnecting non squad peer due to churn: {}", peer_id);
+                            let _ = self.swarm.disconnect_peer_id(peer_id);
+                        }
+
+
+                        // lets trim some connection, this will bring the connections down to a min of 5
+                        // We remove the worst sha and rx chains here
+                        while squad_peers.len() > MAX_OUTBOUND_SQUAD_PEERS.saturating_sub(2){
+                            // we remove one sha3 and one rx
+                            squad_peers.sort_by(|a, b| {
+                                b.peer_info.current_sha3x_pow.cmp(&a.peer_info.current_sha3x_pow)
+                            });
+                            let peer = squad_peers.remove(squad_peers.len()-1);
+
+                            debug!(target: LOG_TARGET, "Disconnecting non squad peer due to churn: {}", peer.peer_id);
+                            let _ = self.swarm.disconnect_peer_id(peer.peer_id);
+                            squad_peers.sort_by(|a, b| {
+                                b.peer_info.current_random_x_pow.cmp(&a.peer_info.current_random_x_pow)
+                            });
+                            let peer = squad_peers.remove(squad_peers.len()-1);
+                            debug!(target: LOG_TARGET, "Disconnecting non squad peer due to churn: {}", peer.peer_id);
+                            let _ = self.swarm.disconnect_peer_id(peer.peer_id);
+                        }
+                        drop(store_read_lock);
+                    }
+                    if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
+                        warn!(target: LOG_TARGET, "Seeking connections took too long: {:?}", timer.elapsed());
                     }
                 },
                 _ = seek_connections_interval.tick() => {
@@ -2670,81 +2728,64 @@ where S: ShareChain
                                 }
                             }
                         }
-
-                        while non_squad_peers.len() > 1 {
-                            let peer_id = non_squad_peers.pop().expect("should be able to pop peer");
-                            let _ = self.swarm.disconnect_peer_id(peer_id);
-                        }
-                        let mut num_dialed = 0;
-                        for record in store_write_lock.random_non_squad_peers_to_dial(20){
-                            if !self.swarm.is_connected(&record.peer_id) &&
-                            !store_write_lock.is_seed_peer(&record.peer_id)
-                            {
-                                store_write_lock.update_last_dial_attempt(&record.peer_id);
-                                info!(
-                                    target: LOG_TARGET,
-                                    "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
-                                    record.peer_id, record.peer_info.current_random_x_height,
-                                    record.peer_info.current_sha3x_height,
-                                    record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
-                                );
-                                let dial_opts = DialOpts::peer_id(record.peer_id)
-                                    .addresses(record.peer_info.public_addresses().clone())
-                                    .extend_addresses_through_behaviour()
-                                    .build();
-                                let _unused = self.swarm.dial(dial_opts).map_err(|e| {
-                                    warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
-                                });
-                                num_dialed += 1;
-                                // We can only do 30 connections
-                                // after 30 it starts cancelling dials
-                                if num_dialed > 1 + MAX_OUTBOUND_NON_SQUAD_PEERS {
-                                    break;
+                        let mut num_dialed = non_squad_peers.len();
+                        if non_squad_peers.len() < MAX_OUTBOUND_NON_SQUAD_PEERS{
+                            debug!(target: LOG_TARGET, "Less than the required non squad peers, dialing non squad peers");
+                            for record in store_write_lock.random_non_squad_peers_to_dial(20){
+                                if !self.swarm.is_connected(&record.peer_id) &&
+                                !store_write_lock.is_seed_peer(&record.peer_id)
+                                {
+                                    store_write_lock.update_last_dial_attempt(&record.peer_id);
+                                    info!(
+                                        target: LOG_TARGET,
+                                        "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
+                                        record.peer_id, record.peer_info.current_random_x_height,
+                                        record.peer_info.current_sha3x_height,
+                                        record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
+                                    );
+                                    let dial_opts = DialOpts::peer_id(record.peer_id)
+                                        .addresses(record.peer_info.public_addresses().clone())
+                                        .extend_addresses_through_behaviour()
+                                        .build();
+                                    let _unused = self.swarm.dial(dial_opts).map_err(|e| {
+                                        warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
+                                    });
+                                    num_dialed += 1;
+                                    // We can only do 30 connections
+                                    // after 30 it starts cancelling dials
+                                    if num_dialed >=  MAX_OUTBOUND_NON_SQUAD_PEERS {
+                                        break;
+                                    }
                                 }
                             }
                         }
+                        if squad_peers.len() < MAX_OUTBOUND_SQUAD_PEERS {
+                            debug!(target: LOG_TARGET, "Less than the required squad peers, dialing squad peers");
+                            for record in store_write_lock.best_squad_peers_to_dial(100) {
+                                if !self.swarm.is_connected(&record.peer_id) &&
+                                    !store_write_lock.is_seed_peer(&record.peer_id)
+                                {
+                                    store_write_lock.update_last_dial_attempt(&record.peer_id);
+                                    info!(
+                                        target: LOG_TARGET,
+                                        "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
+                                        record.peer_id, record.peer_info.current_random_x_height,
+                                        record.peer_info.current_sha3x_height,
+                                        record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
+                                    );
+                                    let dial_opts = DialOpts::peer_id(record.peer_id)
+                                        .addresses(record.peer_info.public_addresses().clone())
+                                        .extend_addresses_through_behaviour()
+                                        .build();
+                                    let _unused = self.swarm.dial(dial_opts).map_err(|e| {
+                                        warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
+                                    });
 
-                        // lets trim some connection, this will bring the connections down to a min of 5
-                        while squad_peers.len() > MAX_OUTBOUND_SQUAD_PEERS.saturating_sub(2){
-                            // we remove one sha3 and one rx
-                            squad_peers.sort_by(|a, b| {
-                                b.peer_info.current_sha3x_pow.cmp(&a.peer_info.current_sha3x_pow)
-                            });
-                            let peer_id = squad_peers.remove(squad_peers.len()-1);
-                            let _ = self.swarm.disconnect_peer_id(peer_id.peer_id);
-                            squad_peers.sort_by(|a, b| {
-                                b.peer_info.current_random_x_pow.cmp(&a.peer_info.current_random_x_pow)
-                            });
-                            let peer_id = squad_peers.remove(squad_peers.len()-1);
-                            let _ = self.swarm.disconnect_peer_id(peer_id.peer_id);
-                        }
-
-
-
-                        for record in store_write_lock.best_squad_peers_to_dial(100) {
-                            if !self.swarm.is_connected(&record.peer_id) &&
-                                !store_write_lock.is_seed_peer(&record.peer_id)
-                            {
-                                store_write_lock.update_last_dial_attempt(&record.peer_id);
-                                info!(
-                                    target: LOG_TARGET,
-                                    "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
-                                    record.peer_id, record.peer_info.current_random_x_height,
-                                    record.peer_info.current_sha3x_height,
-                                    record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
-                                );
-                                let dial_opts = DialOpts::peer_id(record.peer_id)
-                                    .addresses(record.peer_info.public_addresses().clone())
-                                    .extend_addresses_through_behaviour()
-                                    .build();
-                                let _unused = self.swarm.dial(dial_opts).map_err(|e| {
-                                    warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
-                                });
-
-                                num_dialed += 1;
-                                // lets go up to 8 squad connections
-                                if num_dialed >  1 + MAX_OUTBOUND_NON_SQUAD_PEERS + (MAX_OUTBOUND_SQUAD_PEERS.saturating_sub(squad_peers.len())) {
-                                    break;
+                                    num_dialed += 1;
+                                    // lets go up to 8 squad connections
+                                    if num_dialed > MAX_OUTBOUND_NON_SQUAD_PEERS + (MAX_OUTBOUND_SQUAD_PEERS.saturating_sub(squad_peers.len())) {
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -2644,6 +2644,12 @@ where S: ShareChain
                         let info = self.swarm.network_info();
                         let counters = info.connection_counters();
 
+                        let num_connections = counters.num_established_outgoing();
+                        if num_connections == 0 && uptime.elapsed() < Duration::from_secs(60) {
+                            if let Err(e) = self.dial_seed_peers().await {
+                                warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
+                            }
+                         }
                         let mut store_write_lock = self.network_peer_store.write().await;
 
                         let mut squad_peers = Vec::new();
@@ -2656,26 +2662,19 @@ where S: ShareChain
                         for peer in self.swarm.connected_peers(){
                             if let Some(peer_type) = store_write_lock.peer_type(peer){
                                 match peer_type{
-                                    AddPeerStatus::NonSquad => non_squad_peers.push(peer),
+                                    AddPeerStatus::NonSquad => non_squad_peers.push(*peer),
                                     _ => {
                                         if let Some(record) = store_write_lock.get(peer){
-                                            squad_peers.push((peer, record.peer_info.current_sha3x_height, record.peer_info.current_random_x_height))
+                                            squad_peers.push((*peer, record.peer_info.current_sha3x_height, record.peer_info.current_random_x_height))
                                         }
                                     }
                                 }
                             }
                         }
 
-                        let num_connections = counters.num_established_outgoing();
-                        if num_connections == 0 && uptime.elapsed() < Duration::from_secs(60) {
-                            if let Err(e) = self.dial_seed_peers().await {
-                                warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
-                            }
-                         }
-
                         while non_squad_peers.len() > 1 {
                             let peer_id = non_squad_peers.pop().expect("should be able to pop peer");
-                            let _ = self.swarm.disconnect_peer_id(*peer_id);
+                            let _ = self.swarm.disconnect_peer_id(peer_id);
                         }
                         let mut num_dialed = 0;
                         for record in store_write_lock.non_squad_peers().values(){
@@ -2699,12 +2698,12 @@ where S: ShareChain
                                 a.1.cmp(&b.1)
                             });
                             let peer_id = squad_peers.remove(squad_peers.len() / 2);
-                            let _ = self.swarm.disconnect_peer_id(*peer_id.0);
+                            let _ = self.swarm.disconnect_peer_id(peer_id.0);
                             squad_peers.sort_by(|a, b| {
                                 a.2.cmp(&b.2)
                             });
                             let peer_id = squad_peers.remove(squad_peers.len() / 2);
-                            let _ = self.swarm.disconnect_peer_id(*peer_id.0);
+                            let _ = self.swarm.disconnect_peer_id(peer_id.0);
                         }
 
 

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -2710,12 +2710,12 @@ where S: ShareChain
                             squad_peers.sort_by(|a, b| {
                                 b.peer_info.current_sha3x_pow.cmp(&a.peer_info.current_sha3x_pow)
                             });
-                            let peer_id = squad_peers.remove(squad_peers.len());
+                            let peer_id = squad_peers.remove(squad_peers.len()-1);
                             let _ = self.swarm.disconnect_peer_id(peer_id.peer_id);
                             squad_peers.sort_by(|a, b| {
                                 b.peer_info.current_random_x_pow.cmp(&a.peer_info.current_random_x_pow)
                             });
-                            let peer_id = squad_peers.remove(squad_peers.len());
+                            let peer_id = squad_peers.remove(squad_peers.len()-1);
                             let _ = self.swarm.disconnect_peer_id(peer_id.peer_id);
                         }
 

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -55,7 +55,6 @@ use tokio::{
         oneshot,
         OwnedSemaphorePermit,
         RwLock,
-        RwLockWriteGuard,
         Semaphore,
     },
     time::MissedTickBehavior,
@@ -2677,11 +2676,25 @@ where S: ShareChain
                             let _ = self.swarm.disconnect_peer_id(peer_id);
                         }
                         let mut num_dialed = 0;
-                        for record in store_write_lock.non_squad_peers().values(){
+                        for record in store_write_lock.random_non_squad_peers_to_dial(20){
                             if !self.swarm.is_connected(&record.peer_id) &&
                             !store_write_lock.is_seed_peer(&record.peer_id)
                             {
-                                self.dial_peer(&mut store_write_lock, &record);
+                                store_write_lock.update_last_dial_attempt(&record.peer_id);
+                                info!(
+                                    target: LOG_TARGET,
+                                    "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
+                                    record.peer_id, record.peer_info.current_random_x_height,
+                                    record.peer_info.current_sha3x_height,
+                                    record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
+                                );
+                                let dial_opts = DialOpts::peer_id(record.peer_id)
+                                    .addresses(record.peer_info.public_addresses().clone())
+                                    .extend_addresses_through_behaviour()
+                                    .build();
+                                let _unused = self.swarm.dial(dial_opts).map_err(|e| {
+                                    warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
+                                });
                                 num_dialed += 1;
                                 // We can only do 30 connections
                                 // after 30 it starts cancelling dials
@@ -2712,7 +2725,21 @@ where S: ShareChain
                             if !self.swarm.is_connected(&record.peer_id) &&
                                 !store_write_lock.is_seed_peer(&record.peer_id)
                             {
-                                self.dial_peer(&mut store_write_lock, &record);
+                                store_write_lock.update_last_dial_attempt(&record.peer_id);
+                                info!(
+                                    target: LOG_TARGET,
+                                    "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
+                                    record.peer_id, record.peer_info.current_random_x_height,
+                                    record.peer_info.current_sha3x_height,
+                                    record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
+                                );
+                                let dial_opts = DialOpts::peer_id(record.peer_id)
+                                    .addresses(record.peer_info.public_addresses().clone())
+                                    .extend_addresses_through_behaviour()
+                                    .build();
+                                let _unused = self.swarm.dial(dial_opts).map_err(|e| {
+                                    warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
+                                });
 
                                 num_dialed += 1;
                                 // lets go up to 8 squad connections
@@ -2834,23 +2861,6 @@ where S: ShareChain
         }
     }
 
-    async fn dial_peer(&mut self, store_write_lock: &mut RwLockWriteGuard<'_, PeerStore>, record: &PeerStoreRecord) {
-        store_write_lock.update_last_dial_attempt(&record.peer_id);
-        info!(
-            target: LOG_TARGET,
-            "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
-            record.peer_id, record.peer_info.current_random_x_height,
-            record.peer_info.current_sha3x_height,
-            record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
-        );
-        let dial_opts = DialOpts::peer_id(record.peer_id)
-            .addresses(record.peer_info.public_addresses().clone())
-            .extend_addresses_through_behaviour()
-            .build();
-        let _unused = self.swarm.dial(dial_opts).map_err(|e| {
-            warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
-        });
-    }
 
     async fn get_same_squad_peer_records(&self, filter_peers: &[PeerId], is_relay: bool) -> Vec<PeerStoreRecord> {
         let network_peer_store = self.network_peer_store.read().await;

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -55,6 +55,7 @@ use tokio::{
         oneshot,
         OwnedSemaphorePermit,
         RwLock,
+        RwLockWriteGuard,
         Semaphore,
     },
     time::MissedTickBehavior,
@@ -112,6 +113,8 @@ const NUM_PEERS_TO_SYNC_PER_ALGO: usize = 32;
 const NUM_PEERS_INITIAL_SYNC: usize = 100;
 const NUM_PEERS_TO_META_DATA_EXCHANGE: usize = 8;
 const NUM_PEERS_TO_PEER_INFO_EXCHANGE: usize = 8;
+const MAX_OUTBOUND_SQUAD_PEERS: usize = 8;
+const MAX_OUTBOUND_NON_SQUAD_PEERS: usize = 2;
 
 #[derive(Clone, Debug)]
 #[allow(clippy::struct_excessive_bools)]
@@ -1006,7 +1009,7 @@ where S: ShareChain
 
         let source_peer = request.my_info.peer_id;
 
-        info!(target: PEER_INFO_LOGGING_LOG_TARGET, "[META_DATA_REQ] New peer info: {source_peer:?}");
+        info!(target: PEER_INFO_LOGGING_LOG_TARGET, "[META_DATA_REQ] New peer info: {source_peer:?}({})", request.my_info.squad);
         let local_peer_id = *self.swarm.local_peer_id();
         if let Ok(info) = self
             .create_peer_info(self.swarm.external_addresses().cloned().collect())
@@ -1041,7 +1044,7 @@ where S: ShareChain
     }
 
     async fn handle_meta_data_exchange_response(&mut self, response: MetaDataResponse) {
-        info!(target: PEER_INFO_LOGGING_LOG_TARGET, "[META_DATA_EXCHANGE_RESP] New peer info: {}", response.peer_id);
+        info!(target: PEER_INFO_LOGGING_LOG_TARGET, "[META_DATA_EXCHANGE_RESP] New peer info: {}({})", response.peer_id, response.info.squad);
         match response.peer_id.parse::<PeerId>() {
             Ok(peer_id) => {
                 // If they are talking an older version, disconnect
@@ -1517,6 +1520,12 @@ where S: ShareChain
                 // broadcast peer info
                 if let Err(error) = self.broadcast_peer_info().await {
                     warn!(target: LOG_TARGET, "Failed to broadcast peer info: {error:?}");
+                }
+
+                // lets dial the seed peers again, so that they can update our new address
+                // We will disconnect again after a peer sync
+                if let Err(e) = self.dial_seed_peers().await {
+                    warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
                 }
 
                 if timer.elapsed() > MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT {
@@ -2635,44 +2644,80 @@ where S: ShareChain
                         let info = self.swarm.network_info();
                         let counters = info.connection_counters();
 
-                        let num_connections = counters.num_established_outgoing();
-                        if num_connections > 8 {
-                            continue;
+                        let mut store_write_lock = self.network_peer_store.write().await;
+
+                        let mut squad_peers = Vec::new();
+                        let mut non_squad_peers = Vec::new();
+                        // We try and go for 10 outbound connections
+                        // 6 are for good squad peers we want to use
+                        // 2 are for random squad peers so that we dont form islands
+                        // 2 are for non squad peers to no form squad islands
+
+                        for peer in self.swarm.connected_peers(){
+                            if let Some(peer_type) = store_write_lock.peer_type(peer){
+                                match peer_type{
+                                    AddPeerStatus::NonSquad => non_squad_peers.push(peer),
+                                    _ => {
+                                        if let Some(record) = store_write_lock.get(peer){
+                                            squad_peers.push((peer, record.peer_info.current_sha3x_height, record.peer_info.current_random_x_height))
+                                        }
+                                    }
+                                }
+                            }
                         }
+
+                        let num_connections = counters.num_established_outgoing();
                         if num_connections == 0 && uptime.elapsed() < Duration::from_secs(60) {
                             if let Err(e) = self.dial_seed_peers().await {
                                 warn!(target: LOG_TARGET, "Failed to dial seed peers: {e:?}");
                             }
                          }
 
+                        while non_squad_peers.len() > 1 {
+                            let peer_id = non_squad_peers.pop().expect("should be able to pop peer");
+                            let _ = self.swarm.disconnect_peer_id(*peer_id);
+                        }
                         let mut num_dialed = 0;
-                        let mut store_write_lock = self.network_peer_store.write().await;
-
-                        let mut peers_to_dial = vec![];
-                        for record in store_write_lock.best_peers_to_dial(100) {
-                            // Only dial seed peers if we have 0 connections
+                        for record in store_write_lock.non_squad_peers().values(){
                             if !self.swarm.is_connected(&record.peer_id) &&
-                                !store_write_lock.is_seed_peer(&record.peer_id)
+                            !store_write_lock.is_seed_peer(&record.peer_id)
                             {
-                                store_write_lock.update_last_dial_attempt(&record.peer_id);
-                                info!(
-                                    target: LOG_TARGET,
-                                    "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
-                                    record.peer_id, record.peer_info.current_random_x_height,
-                                    record.peer_info.current_sha3x_height,
-                                    record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
-                                );
-                                let dial_opts = DialOpts::peer_id(record.peer_id).addresses(
-                                    record.peer_info.public_addresses().clone()
-                                ).extend_addresses_through_behaviour().build();
-                                let _unused = self.swarm.dial(dial_opts).map_err(|e| {
-                                    warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
-                                });
-                                peers_to_dial.push(record.peer_id);
+                                self.dial_peer(&mut store_write_lock, &record);
                                 num_dialed += 1;
                                 // We can only do 30 connections
                                 // after 30 it starts cancelling dials
-                                if num_dialed > 10 {
+                                if num_dialed > 1 + MAX_OUTBOUND_NON_SQUAD_PEERS {
+                                    break;
+                                }
+                            }
+                        }
+
+                        // lets trim some connection, this will bring the connections down to a min of 5
+                        while squad_peers.len() > 6{
+                            // we remove one sha3 and one rx
+                            squad_peers.sort_by(|a, b| {
+                                a.1.cmp(&b.1)
+                            });
+                            let peer_id = squad_peers.remove(squad_peers.len() / 2);
+                            let _ = self.swarm.disconnect_peer_id(*peer_id.0);
+                            squad_peers.sort_by(|a, b| {
+                                a.2.cmp(&b.2)
+                            });
+                            let peer_id = squad_peers.remove(squad_peers.len() / 2);
+                            let _ = self.swarm.disconnect_peer_id(*peer_id.0);
+                        }
+
+
+
+                        for record in store_write_lock.best_squad_peers_to_dial(100) {
+                            if !self.swarm.is_connected(&record.peer_id) &&
+                                !store_write_lock.is_seed_peer(&record.peer_id)
+                            {
+                                self.dial_peer(&mut store_write_lock, &record);
+
+                                num_dialed += 1;
+                                // lets go up to 8 squad connections
+                                if num_dialed >  1 + MAX_OUTBOUND_NON_SQUAD_PEERS + (MAX_OUTBOUND_SQUAD_PEERS.saturating_sub(squad_peers.len())) {
                                     break;
                                 }
                             }
@@ -2788,6 +2833,24 @@ where S: ShareChain
                 },
             }
         }
+    }
+
+    async fn dial_peer(&mut self, store_write_lock: &mut RwLockWriteGuard<'_, PeerStore>, record: &PeerStoreRecord) {
+        store_write_lock.update_last_dial_attempt(&record.peer_id);
+        info!(
+            target: LOG_TARGET,
+            "Dialing peer: {:?} with height(rx/sha) {}/{} on {}",
+            record.peer_id, record.peer_info.current_random_x_height,
+            record.peer_info.current_sha3x_height,
+            record.peer_info.public_addresses().iter().map(|a| a.to_string()).collect::<Vec<String>>().join(", ")
+        );
+        let dial_opts = DialOpts::peer_id(record.peer_id)
+            .addresses(record.peer_info.public_addresses().clone())
+            .extend_addresses_through_behaviour()
+            .build();
+        let _unused = self.swarm.dial(dial_opts).map_err(|e| {
+            warn!(target: LOG_TARGET, "Failed to dial peer: {e:?}");
+        });
     }
 
     async fn get_same_squad_peer_records(&self, filter_peers: &[PeerId], is_relay: bool) -> Vec<PeerStoreRecord> {

--- a/p2pool/src/server/p2p/peer_store.rs
+++ b/p2pool/src/server/p2p/peer_store.rs
@@ -6,9 +6,10 @@ use std::{
     str::FromStr,
     time::Instant,
 };
-use rand::thread_rng;
+
 use libp2p::PeerId;
 use log::*;
+use rand::thread_rng;
 use tari_core::proof_of_work::PowAlgorithm;
 use tari_utilities::epoch_time::EpochTime;
 

--- a/p2pool/src/server/p2p/peer_store.rs
+++ b/p2pool/src/server/p2p/peer_store.rs
@@ -234,9 +234,8 @@ impl PeerStore {
         peers.into_iter().cloned().collect()
     }
 
-    pub fn best_peers_to_dial(&self, count: usize) -> Vec<PeerStoreRecord> {
+    pub fn best_squad_peers_to_dial(&self, count: usize) -> Vec<PeerStoreRecord> {
         let mut peers = self.whitelist_peers.values().collect::<Vec<_>>();
-        peers.extend(self.non_squad_peers.values().collect::<Vec<_>>());
         peers.retain(|peer| {
             !peer.peer_info.public_addresses().is_empty() &&
                 (peer.last_dial_attempt.is_none() || peer.last_dial_attempt.unwrap().elapsed().as_secs() > 120)
@@ -257,6 +256,16 @@ impl PeerStore {
 
     pub fn update_last_dial_attempt(&mut self, peer_id: &PeerId) {
         if let Some(entry) = self.whitelist_peers.get_mut(&peer_id.to_base58()) {
+            let mut new_record = entry.clone();
+            new_record.last_dial_attempt = Some(Instant::now());
+            *entry = new_record;
+        }
+        if let Some(entry) = self.greylist_peers.get_mut(&peer_id.to_base58()) {
+            let mut new_record = entry.clone();
+            new_record.last_dial_attempt = Some(Instant::now());
+            *entry = new_record;
+        }
+        if let Some(entry) = self.non_squad_peers.get_mut(&peer_id.to_base58()) {
             let mut new_record = entry.clone();
             new_record.last_dial_attempt = Some(Instant::now());
             *entry = new_record;
@@ -303,6 +312,20 @@ impl PeerStore {
     /// If a peer already exists, just replaces it.
     pub async fn add(&mut self, peer_id: PeerId, peer_info: PeerInfo) -> AddPeerStatus {
         debug!(target: LOG_TARGET, "Try add peer to store: {}", peer_id);
+
+        if peer_info.squad != self.my_squad {
+            info!(target: LOG_TARGET, "Peer non squad peer: {}", peer_id);
+            let return_type = if self.non_squad_peers.contains_key(&peer_id.to_base58()) {
+                AddPeerStatus::NonSquad
+            } else {
+                AddPeerStatus::Existing
+            };
+            self.non_squad_peers
+                .insert(peer_id.to_base58(), PeerStoreRecord::new(peer_id, peer_info));
+            self.update_peer_stats();
+            return return_type;
+        }
+
         // Seed peers are automatically greylisted so that we don't overwhelm them with syncs
         if self.seed_peers.contains(&peer_id) {
             let mut peer_record = PeerStoreRecord::new(peer_id, peer_info.clone());
@@ -318,18 +341,6 @@ impl PeerStore {
 
         if let Some(_grey) = self.greylist_peers.get(&peer_id.to_base58()) {
             return AddPeerStatus::Greylisted;
-        }
-
-        if peer_info.squad != self.my_squad {
-            let return_type = if self.non_squad_peers.contains_key(&peer_id.to_base58()) {
-                AddPeerStatus::NonSquad
-            } else {
-                AddPeerStatus::Existing
-            };
-            self.non_squad_peers
-                .insert(peer_id.to_base58(), PeerStoreRecord::new(peer_id, peer_info));
-            self.update_peer_stats();
-            return return_type;
         }
 
         if let Some(entry) = self.whitelist_peers.get_mut(&peer_id.to_base58()) {
@@ -420,6 +431,22 @@ impl PeerStore {
 
     pub fn is_blacklisted(&self, peer_id: &PeerId) -> bool {
         self.blacklist_peers.contains_key(&peer_id.to_base58())
+    }
+
+    pub fn peer_type(&self, peer_id: &PeerId) -> Option<AddPeerStatus> {
+        if self.whitelist_peers.contains_key(&peer_id.to_base58()) {
+            return Some(AddPeerStatus::Existing);
+        }
+        if self.greylist_peers.contains_key(&peer_id.to_base58()) {
+            return Some(AddPeerStatus::Greylisted);
+        }
+        if self.blacklist_peers.contains_key(&peer_id.to_base58()) {
+            return Some(AddPeerStatus::Blacklisted);
+        }
+        if self.non_squad_peers.contains_key(&peer_id.to_base58()) {
+            return Some(AddPeerStatus::NonSquad);
+        }
+        None
     }
 
     // pub fn is_whitelisted(&self, peer_id: &PeerId) -> bool {

--- a/p2pool/src/server/p2p/peer_store.rs
+++ b/p2pool/src/server/p2p/peer_store.rs
@@ -326,9 +326,9 @@ impl PeerStore {
         if peer_info.squad != self.my_squad {
             info!(target: LOG_TARGET, "Peer non squad peer: {}", peer_id);
             let return_type = if self.non_squad_peers.contains_key(&peer_id.to_base58()) {
-                AddPeerStatus::NonSquad
-            } else {
                 AddPeerStatus::Existing
+            } else {
+                AddPeerStatus::NonSquad
             };
             self.non_squad_peers
                 .insert(peer_id.to_base58(), PeerStoreRecord::new(peer_id, peer_info));

--- a/p2pool/src/server/p2p/peer_store.rs
+++ b/p2pool/src/server/p2p/peer_store.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
     time::Instant,
 };
-
+use rand::thread_rng;
 use libp2p::PeerId;
 use log::*;
 use tari_core::proof_of_work::PowAlgorithm;
@@ -260,6 +260,9 @@ impl PeerStore {
             !peer.peer_info.public_addresses().is_empty() &&
                 (peer.last_dial_attempt.is_none() || peer.last_dial_attempt.unwrap().elapsed().as_secs() > 120)
         });
+        // Shuffle the peers for true randomization
+        use rand::seq::SliceRandom;
+        peers.shuffle(&mut thread_rng());
         peers.truncate(count);
         peers.into_iter().cloned().collect()
     }

--- a/p2pool/src/server/p2p/peer_store.rs
+++ b/p2pool/src/server/p2p/peer_store.rs
@@ -254,6 +254,16 @@ impl PeerStore {
         peers.into_iter().cloned().collect()
     }
 
+    pub fn random_non_squad_peers_to_dial(&self, count: usize) -> Vec<PeerStoreRecord> {
+        let mut peers = self.non_squad_peers.values().collect::<Vec<_>>();
+        peers.retain(|peer| {
+            !peer.peer_info.public_addresses().is_empty() &&
+                (peer.last_dial_attempt.is_none() || peer.last_dial_attempt.unwrap().elapsed().as_secs() > 120)
+        });
+        peers.truncate(count);
+        peers.into_iter().cloned().collect()
+    }
+
     pub fn update_last_dial_attempt(&mut self, peer_id: &PeerId) {
         if let Some(entry) = self.whitelist_peers.get_mut(&peer_id.to_base58()) {
             let mut new_record = entry.clone();


### PR DESCRIPTION
Description
---
This changes how p2pool does peer selection

Currently, we just try to select 8 outbound peers. We try to choose these by latency. This can cause the peers tp form islands. 

This changes to peer selection to be beneficial for the network. We choose 2 peers that are not of our squad so that we can propagate gossip messages across the entire network, like network changes. We change 1 of these periodically. 

We still try and keep 8 peers of our squad as outbound connections, but we drop the middle connection in terms of block height so that low nodes can sync from us and try catcup, and we replace those 2 with 2 new peers. This is to stop nodes from just connecting to the same peers, and cycle some of them to ensure we have a fully connected network. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced network connectivity by introducing dynamic limits that differentiate squad from non-squad connections.
  - Rolled out targeted mechanisms for selecting optimal squad peers, improving overall connection reliability.
  - Added functionality to specifically handle dialing non-squad peers.
  - Introduced a method for classifying peers based on their status in various lists.

- **Refactor**
  - Overhauled the underlying connection management logic to adapt more effectively to changing network conditions.
  - Updated logging enhancements for improved tracking of connection activities.
  - Improved peer management with structured methods for classifying and dialing peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->