### PR TITLE
fix: fix dhat profile build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ resolver = "2"
 
 
 [profile.release]
+overflow-checks = true
 opt-level = 3
 debug = false
-overflow-checks = true
-
+# To enable debug symbols with dhat profiling in release mode, enable the 'dhat-heap' feature and use
+# CARGO_PROFILE_* Environment Variables:
+#   CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --features=dhat-heap               ...(Linux)
+#   $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; cargo build --release --features=dhat-heap     ...(PowerShell)
+ 

--- a/p2pool/Cargo.toml
+++ b/p2pool/Cargo.toml
@@ -84,11 +84,8 @@ name = "sha_p2pool"
 path = "src/main.rs"
 
 [features]
-dhat-heap = []    # if you are doing heap profiling
-
-[profile.release]
-opt-level = 3
-debug = false
-
-[profile.release.dhat-heap]
-debug = true
+# If you are doing heap profiling, use 'dhat-heap' and enable debug symbols:
+#   CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --bin minotari_node --features=dhat-heap            ...(Linux)
+#   $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; cargo build --release --bin minotari_node --features=dhat-heap  ...(PowerShell)
+dhat-heap = []
+ 


### PR DESCRIPTION
Description
---
Fixed dhat profile build

Motivation and Context
---
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/schalkvanheerden/Code/sha-p2pool/p2pool/Cargo.toml
workspace: /Users/schalkvanheerden/Code/sha-p2pool/Cargo.toml
warning: /Users/schalkvanheerden/Code/sha-p2pool/p2pool/Cargo.toml: unused manifest key: profile.release.dhat-heap
```

How Has This Been Tested?
---
Build

What process can a PR reviewer use to test or verify this change?
---
Build

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced release build safety by reactivating runtime overflow checks.
  - Streamlined build configuration with clear instructions for enabling debug symbols during heap profiling, including guidance for Linux and PowerShell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->