### PR TITLE
feat!: mainnet topic

### DIFF
--- a/p2pool/src/server/mod.rs
+++ b/p2pool/src/server/mod.rs
@@ -15,7 +15,7 @@ pub mod grpc;
 pub mod http;
 pub mod p2p;
 
-pub const PROTOCOL_VERSION: u64 = 35;
+pub const PROTOCOL_VERSION: u64 = 36;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub(crate) enum PeerType {

--- a/p2pool/src/sharechain/p2block.rs
+++ b/p2pool/src/sharechain/p2block.rs
@@ -8,6 +8,7 @@ use blake2::Blake2b;
 use digest::consts::U32;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use tari_common::configuration::Network;
 use tari_common_types::{
     tari_address::TariAddress,
     types::{BlockHash, FixedHash},
@@ -29,12 +30,12 @@ use crate::{
 
 lazy_static! {
     pub static ref CURRENT_CHAIN_ID: String = {
-        // let network = Network::get_current_or_user_setting_or_default();
+        let network = Network::get_current_or_user_setting_or_default();
         // let network_genesis_block = get_genesis_block(network);
         // let network_genesis_block_hash = network_genesis_block.block().header.hash().to_hex();
         // This is hard coded for compatibility
-        let network_genesis_block_hash = "6df34a9e6e40e0e28222aa36a668e17a1b8f5d62beca70dea96ac729104fa402";
-        format!("{network_genesis_block_hash}_{CHAIN_ID}")
+        // let network_genesis_block_hash = "6df34a9e6e40e0e28222aa36a668e17a1b8f5d62beca70dea96ac729104fa402";
+        format!("{network}_{CHAIN_ID}")
     };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the protocol version to 36.
  - Changed the format of the chain identifier to use the current network name instead of the genesis block hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->