### PR TITLE
feat: cli config for num of synced peers

### DIFF
--- a/integration_tests/src/p2pool_process.rs
+++ b/integration_tests/src/p2pool_process.rs
@@ -194,6 +194,7 @@ pub async fn spawn_p2pool_node_and_wait_for_start(
         sha3x_disabled: !node_config.p2p_service.sha3x_enabled,
         block_time_sha: Some(1),
         block_time_rx: Some(1),
+        num_concurrent_syncs: Some(1),
         share_window: Some(100),
         export_libp2p_info: Some(temp_dir_path.join(LIBP2P_INFO_FILE).clone()),
         network_silence_delay: {

--- a/p2pool/src/cli/args.rs
+++ b/p2pool/src/cli/args.rs
@@ -147,6 +147,9 @@ pub struct StartArgs {
     #[arg(long, value_name = "btr")]
     pub block_time_rx: Option<u64>,
 
+    #[arg(long, value_name = "ncs")]
+    pub num_concurrent_syncs: Option<u32>,
+
     #[arg(long, value_name = "sw")]
     pub share_window: Option<u64>,
 

--- a/p2pool/src/cli/commands/util.rs
+++ b/p2pool/src/cli/commands/util.rs
@@ -80,6 +80,10 @@ pub async fn server(
     if let Some(block_time) = args.block_time_rx {
         config_builder.with_rx_block_time(block_time);
     }
+    
+    if let Some(num_concurrent_syncs) = args.num_concurrent_syncs{
+        config_builder.with_num_concurrent_syncs(num_concurrent_syncs as usize);
+    }
 
     if let Some(share_window) = args.share_window {
         config_builder.with_share_window(share_window);

--- a/p2pool/src/cli/commands/util.rs
+++ b/p2pool/src/cli/commands/util.rs
@@ -80,8 +80,8 @@ pub async fn server(
     if let Some(block_time) = args.block_time_rx {
         config_builder.with_rx_block_time(block_time);
     }
-    
-    if let Some(num_concurrent_syncs) = args.num_concurrent_syncs{
+
+    if let Some(num_concurrent_syncs) = args.num_concurrent_syncs {
         config_builder.with_num_concurrent_syncs(num_concurrent_syncs as usize);
     }
 

--- a/p2pool/src/server/config.rs
+++ b/p2pool/src/server/config.rs
@@ -255,6 +255,11 @@ impl ConfigBuilder {
         self.config.p2p_service.diagnostic_mode = config;
         self
     }
+    
+    pub fn with_num_concurrent_syncs(&mut self, config: usize) -> &mut Self {
+        self.config.p2p_service.num_concurrent_syncs = config;
+        self
+    }
 
     pub fn build(&self) -> Config {
         self.config.clone()

--- a/p2pool/src/server/config.rs
+++ b/p2pool/src/server/config.rs
@@ -255,7 +255,7 @@ impl ConfigBuilder {
         self.config.p2p_service.diagnostic_mode = config;
         self
     }
-    
+
     pub fn with_num_concurrent_syncs(&mut self, config: usize) -> &mut Self {
         self.config.p2p_service.num_concurrent_syncs = config;
         self


### PR DESCRIPTION
Description
---
Allow the change of the number of synced peers to be changed via the cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new command-line option to set the number of concurrent syncs for node startup.
	- Users can now configure concurrent syncs via the CLI for improved control over node synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->