### PR TITLE
fix: block gossip

### DIFF
--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -521,6 +521,29 @@ where S: ShareChain
         format!("{network}_{chain_id}_{squad}_{topic}_{PROTOCOL_VERSION}")
     }
 
+    /// Generates a gossip sub topic name based on the current Tari network to avoid mixing up
+    /// blocks and peers with different Tari networks and the given squad name.
+    fn match_non_squad_topic(&self, topic: &str, message_topic: &str) -> bool {
+        let network = Network::get_current_or_user_setting_or_default().as_key_str();
+        let chain_id = CURRENT_CHAIN_ID.clone();
+        let squad = &self.squad;
+        let topic = format!("{network}_{chain_id}_{squad}_{topic}_{PROTOCOL_VERSION}");
+        let parts = topic.split('_');
+        let message_parts = message_topic.split('_');
+        if parts.count() != message_parts.count() {
+            return false;
+        }
+        for (part, message_part) in parts.zip(message_parts) {
+            if part == squad {
+                continue;
+            };
+            if part != message_part {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Subscribing to a gossipsub topic.
     fn subscribe(&mut self, topic: &str, squad: bool) {
         let topic = if squad {
@@ -796,6 +819,14 @@ where S: ShareChain
                             return Ok(MessageAcceptance::Reject);
                         },
                     }
+                },
+                topic
+                    if self.match_non_squad_topic(BLOCK_NOTIFY_TOPIC, &topic) ||
+                        self.match_non_squad_topic(BLOCK_NOTIFY_RX_TOPIC, &topic) ||
+                        self.match_non_squad_topic(BLOCK_NOTIFY_SHA3X_TOPIC, &topic) =>
+                {
+                    debug!(target: MESSAGE_LOGGING_LOG_TARGET, "Non squad block, ignoring and passing on");
+                    return Ok(MessageAcceptance::Accept);
                 },
                 _ => {
                     debug!(target: MESSAGE_LOGGING_LOG_TARGET, "Unknown topic {topic:?}!");

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -825,7 +825,7 @@ where S: ShareChain
                         self.match_non_squad_topic(BLOCK_NOTIFY_RX_TOPIC, &topic) ||
                         self.match_non_squad_topic(BLOCK_NOTIFY_SHA3X_TOPIC, &topic) =>
                 {
-                    debug!(target: MESSAGE_LOGGING_LOG_TARGET, "Non squad block, ignoring and passing on");
+                    debug!(target: LOG_TARGET, "Non squad block, ignoring and passing on");
                     return Ok(MessageAcceptance::Accept);
                 },
                 _ => {

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -528,12 +528,12 @@ where S: ShareChain
         let chain_id = CURRENT_CHAIN_ID.clone();
         let squad = &self.squad;
         let topic = format!("{network}_{chain_id}_{squad}_{topic}_{PROTOCOL_VERSION}");
-        let parts = topic.split('_');
-        let message_parts = message_topic.split('_');
-        if parts.count() != message_parts.count() {
+        let parts: Vec<&str> = topic.split('_').collect();
+        let message_parts: Vec<&str> = message_topic.split('_').collect();
+        if parts.len() != message_parts.len() {
             return false;
         }
-        for (part, message_part) in parts.zip(message_parts) {
+        for (part, message_part) in parts.into_iter().zip(message_parts) {
             if part == squad {
                 continue;
             };


### PR DESCRIPTION
Description
---
Pass block gossip onto the rest of the network if its from a different squad, and don't reject it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of block notification messages from other squads. Such messages are now identified and logged as "Non squad block, ignoring and passing on," ensuring they are accepted but not processed further.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->