### PR TITLE
fix: accept higher block tips and reduce catchup sync size

### DIFF
--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -107,7 +107,7 @@ const MAX_ACCEPTABLE_P2P_MESSAGE_TIMEOUT: Duration = Duration::from_millis(500);
 const MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT: Duration = Duration::from_millis(100);
 const CATCH_UP_SYNC_BLOCKS_IN_I_HAVE: usize = 100;
 const MAX_CATCH_UP_ATTEMPTS: u64 = 500;
-const MAX_CATCH_UP_BLOCKS_TO_RETURN: usize = 10;
+const MAX_CATCH_UP_BLOCKS_TO_RETURN: usize = 2;
 // Time to start up and catch up before we start processing new tip messages
 const NUM_PEERS_TO_SYNC_PER_ALGO: usize = 32;
 const NUM_PEERS_INITIAL_SYNC: usize = 100;
@@ -711,8 +711,8 @@ where S: ShareChain
                                     "Peer {} sent a block that is much higher than ours, skipping",
                                     message_peer
                                 );
-                                // Is reject too harsh? Maybe we should just ignore it
-                                return Ok(MessageAcceptance::Ignore);
+                                // Return accept so that the rest of the network can get it
+                                return Ok(MessageAcceptance::Accept);
                             }
 
                             let max_payload_height = payload

--- a/p2pool/src/server/p2p/network.rs
+++ b/p2pool/src/server/p2p/network.rs
@@ -107,7 +107,7 @@ const MAX_ACCEPTABLE_P2P_MESSAGE_TIMEOUT: Duration = Duration::from_millis(500);
 const MAX_ACCEPTABLE_NETWORK_EVENT_TIMEOUT: Duration = Duration::from_millis(100);
 const CATCH_UP_SYNC_BLOCKS_IN_I_HAVE: usize = 100;
 const MAX_CATCH_UP_ATTEMPTS: u64 = 500;
-const MAX_CATCH_UP_BLOCKS_TO_RETURN: usize = 2;
+const MAX_CATCH_UP_BLOCKS_TO_RETURN: usize = 5;
 // Time to start up and catch up before we start processing new tip messages
 const NUM_PEERS_TO_SYNC_PER_ALGO: usize = 32;
 const NUM_PEERS_INITIAL_SYNC: usize = 100;


### PR DESCRIPTION
Change from ignoring higher new block notifies to accepting them, so that the rest of the network receives them.
Also reduces the max number of blocks to send via catchup sync. This will potentially slow down catchup sync, but currently there is a 10mb limit on cbor for responses and I think we are hitting that limit.

In future it might be better to pass a number of blocks to sync so that the client and server can negotiate a rate.

UPDATE: changed to 5 to be more conservative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Reduced the maximum number of blocks returned during catch-up synchronization from 10 to 5.
  - Updated message handling to accept and propagate blocks significantly ahead of the local tip instead of ignoring them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->